### PR TITLE
fix: replace hardcoded path with Qt.resolvedUrl in Panel.qml

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -196,7 +196,7 @@ Panel {
     iconComponent: Component {
       Image {
         anchors.fill: parent
-        source: "file:///home/alberto/repo/agent-orchestr/assets/icons/agent.svg"
+        source: Qt.resolvedUrl("assets/icons/agent.svg")
         sourceSize.width: Style.bar.iconCanvas * 2
         sourceSize.height: Style.bar.iconCanvas * 2
         fillMode: Image.PreserveAspectFit


### PR DESCRIPTION
## Summary

Replaces the hardcoded `file:///home/alberto/repo/agent-orchestr/assets/icons/agent.svg` path in `Panel.qml:199` with `Qt.resolvedUrl("assets/icons/agent.svg")`, which resolves relative to the file's own directory.

This matches the pattern already used on lines 514 and 549 of the same file.

## Impact

The bar widget brand-mark icon (the default agent icon) now renders correctly on any install location, not just the developer's machine.

## Fixes

Closes #2