### PR TITLE
fix: declare Text.PlainText on all QML Text elements (marketplace #4578 block)

### DIFF
--- a/Model.js
+++ b/Model.js
@@ -154,6 +154,10 @@ function formatBarHeadline(summary, displayMode, maxLen) {
 }
 
 function getTooltipText(summary) {
+  // SECURITY CONTRACT: tooltip strings are rendered by the host bar (textFormat
+  // outside this plugin's control), so this must stay numeric-coerced fields and
+  // fixed literals only — never route raw agent-controlled JSON strings (e.g.
+  // summary.headline, labels) into the returned text.
   if (!summary) return "Agent Orchestrator"
   var total = Number(summary.total) || 0
   var working = Number(summary.working) || 0

--- a/Panel.qml
+++ b/Panel.qml
@@ -235,6 +235,7 @@ Panel {
 
         Text {
           text: String(root.summary.waiting > 0 ? root.summary.waiting : (root.summary.working > 0 ? root.summary.working : root.summary.total))
+          textFormat: Text.PlainText
           font.family: root.fontFamily
           font.pixelSize: Style.space(8)
           font.bold: true
@@ -271,6 +272,7 @@ Panel {
       Text {
         id: chipIcon
         text: ""
+        textFormat: Text.PlainText
         font.family: root.fontFamily
         font.pixelSize: Style.font.body
         color: root.summary.waiting > 0 ? "#F59E0B" : (root.summary.working > 0 ? root.accent : root.foreground)
@@ -338,6 +340,7 @@ Panel {
         Text {
           text: ""
           color: root.summary.waiting > 0 ? "#F59E0B" : (root.summary.working > 0 ? root.accent : root.foreground)
+          textFormat: Text.PlainText
           font.family: root.fontFamily
           font.pixelSize: Style.space(32)
           Layout.alignment: Qt.AlignVCenter
@@ -351,6 +354,7 @@ Panel {
           Text {
             text: "Agent Orchestrator"
             color: root.foreground
+            textFormat: Text.PlainText
             font.family: root.fontFamily
             font.pixelSize: Style.font.title
             font.bold: true
@@ -380,6 +384,7 @@ Panel {
             anchors.centerIn: parent
             text: "󰑐"
             color: root.foreground
+            textFormat: Text.PlainText
             font.family: root.fontFamily
             font.pixelSize: Style.space(14)
             rotation: root.loading ? 360 : 0
@@ -439,6 +444,7 @@ Panel {
             Text {
               anchors.centerIn: parent
               text: modelData.label
+              textFormat: Text.PlainText
               font.family: root.fontFamily
               font.pixelSize: Style.space(11)
               font.weight: root.selectedFilter === modelData.id ? Font.DemiBold : Font.Normal
@@ -554,12 +560,14 @@ Panel {
                     Text {
                       visible: !Boolean(Model.originIconPath(modelData.origin)) && Boolean(Model.originIcon(modelData.origin))
                       text: Model.originIcon(modelData.origin)
+                      textFormat: Text.PlainText
                       font.family: root.fontFamily
                       font.pixelSize: Style.space(8)
                       color: Model.originColor(modelData.origin)
                     }
                     Text {
                       text: Model.originBadgeText(modelData.origin)
+                      textFormat: Text.PlainText
                       font.family: root.fontFamily
                       font.pixelSize: Style.space(8)
                       font.bold: true
@@ -616,6 +624,7 @@ Panel {
 
                     Text {
                       text: Model.statusBadgeText(modelData.status)
+                      textFormat: Text.PlainText
                       font.family: root.fontFamily
                       font.pixelSize: Style.space(9)
                       font.bold: true
@@ -636,6 +645,7 @@ Panel {
                   Text {
                     anchors.centerIn: parent
                     text: "✕"
+                    textFormat: Text.PlainText
                     font.family: root.fontFamily
                     font.pixelSize: Style.space(10)
                     font.bold: true
@@ -704,6 +714,7 @@ Panel {
                     spacing: Style.space(3)
                     Text {
                       text: "📁"
+                      textFormat: Text.PlainText
                       font.pixelSize: Style.space(9)
                     }
                     Text {
@@ -775,6 +786,7 @@ Panel {
                     : (root.rawData.connected) ? "Herdr + Terminal Live"
                     : (root.rawData.orca_connected) ? "Orca Scanner Active"
                     : "Standalone Scanner Active"
+              textFormat: Text.PlainText
               font.family: root.fontFamily
               font.pixelSize: Style.space(9)
               color: root.dim
@@ -786,6 +798,7 @@ Panel {
           // Keyboard hint
           Text {
             text: "Click card to focus · ✕ to terminate"
+            textFormat: Text.PlainText
             font.family: root.fontFamily
             font.pixelSize: Style.space(9)
             color: root.dim

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ omarchy shell meviusisback.agent-orchestr refresh
 - **Read-Only SQLite & Session Parsing**: Hermes databases are queried strictly with `?mode=ro`, and OMP transcripts are parsed in read-only mode.
 - **Safe Process Signaling**: Process termination verifies the target PID against active AI agent process signatures before signaling.
 - **Shell & Injection Safety**: All subprocess and Hyprland dispatch operations use discrete argument vectors without shell evaluation, and QML Text components enforce plain-text formatting.
+- **Plain-Text Convention**: Every `Text` element in `Panel.qml` must declare `textFormat: Text.PlainText` explicitly — agent-supplied strings (titles, labels, paths) must never render through QML's default `AutoText`, which would interpret rich-text markup as shell UI. New widgets should preserve this invariant.
 ## License
 
 MIT

--- a/agent_ctl.py
+++ b/agent_ctl.py
@@ -893,7 +893,7 @@ _ORCA_AGENT_ALIASES = {
 # Bare shells / system programs that mean "no agent in this terminal".
 _ORCA_BARE_SHELLS = {
     "zsh", "bash", "sh", "fish", "nushell", "nu", "dash", "ksh",
-    "alberto@omarchy", "omarchy", "shell", "su" + "do", "pacman", "vim", "nvim",
+    "alberto@omarchy", "omarchy", "shell", "sudo", "pacman", "vim", "nvim",
 }
 
 # While an agent works inside a tab, Orca renames the tab to a dynamic title


### PR DESCRIPTION
## Summary
Marketplace verification (omacom/omarchy-plugin-marketplace#4578) was blocked by HANCORE-linux: `Panel.qml:439` and related views rendered agent/session labels and status data without `Text.PlainText`, so plugin- or agent-controlled text could become shell UI markup via QML's default `Text.AutoText`.

## Changes
- **Panel.qml** (4d57562): add `textFormat: Text.PlainText` to the 13 `Text` elements that relied on the `AutoText` default — all 21/21 Text blocks now pin PlainText explicitly. Purely additive; no layout or behavior change (no string in the UI contains intentional markup).
- **agent_ctl.py** (eac10ac): revert the `"su"+"do"` string split from a9651e4 back to a plain `"sudo"` literal. Security review flagged the split as static-scan evasion that undermines verifier trust; set membership is byte-identical.
- **README.md / Model.js** (fb11740): document the plain-text convention invariant and the `getTooltipText` numeric-only security contract (tooltip renders in the host bar, outside this plugin's `textFormat` control).

## Security Review
- [x] Code quality review passed (diff purity, brace-stack placement, 21/21 coverage)
- [x] Security audit passed (0 critical/high; both low findings addressed in-repo)
- [x] QML specialist review passed (no rich-text regressions, no binding/lifecycle impact)

## Testing
- [x] `qmllint Panel.qml`: 0 errors (same as baseline)
- [x] `python3 agent_ctl.py status`: valid JSON, 5 agents, no token patterns in stdout/stderr
- [x] `py_compile agent_ctl.py` + `node --check Model.js` pass
- [x] Runtime-identical `"sudo"` membership asserted post-import

Addresses the review blocker in [omacom/omarchy-plugin-marketplace#4578](https://github.com/omacom/omarchy-plugin-marketplace/issues/4578) — that verify request stays open until a new one targets the merged commit.
