### PR TITLE
fix(scan): exclude Claude Code helper processes from agent discovery

### DIFF
--- a/agent_ctl.py
+++ b/agent_ctl.py
@@ -230,6 +230,21 @@ def is_hermes_cli_process(cmd: str) -> bool:
     )
 
 
+# Claude Code runs internal helpers under the same `claude` binary (argv[0]).
+# They are identifiable by a literal subcommand verb in argv[1]; real sessions
+# are invoked as `claude --session-id …`, `claude --resume …` or bare `claude`,
+# where the second token is a flag or absent. (Ref: issue #10)
+CLAUDE_HELPER_SUBCOMMANDS = ("daemon", "bg-pty-host", "bg-spare")
+
+
+def is_claude_helper_process(cmd: str) -> bool:
+    """True for Claude Code internal helper processes (daemon, bg-pty-host, bg-spare)."""
+    tokens = cmd.split()
+    if len(tokens) < 2 or os.path.basename(tokens[0]) != "claude":
+        return False
+    return tokens[1] in CLAUDE_HELPER_SUBCOMMANDS
+
+
 def is_valid_agent_process(pid: int) -> bool:
     """Validate that a PID actually corresponds to an active AI agent process before signaling."""
     if pid <= 1:
@@ -240,7 +255,7 @@ def is_valid_agent_process(pid: int) -> bool:
     cmd = info["cmd"]
     tokens = cmd.split()
     first = os.path.basename(tokens[0]) if tokens else ""
-    if first in ("omp", "pi", "claude", "codex", "opencode", "cline", "cursor", "agy"):
+    if first in ("omp", "pi", "claude", "codex", "opencode", "cline", "cursor", "agy") and not is_claude_helper_process(cmd):
         return True
     if first in ("python", "python3") and is_hermes_cli_process(cmd):
         return True
@@ -1273,7 +1288,7 @@ def scan_standalone_agents(herdr_server_pids: List[int], seen_cwds: Set[str], cl
             )
 
             # Skip anything running inside Herdr, spawned as an internal background worker, or system usage script
-            if is_in_herdr or is_broker_child or "omarchy-agent-usage" in cmd or "__omp_worker" in cmd or "gateway run" in cmd or "serve --host" in cmd or "zygote" in cmd or "agent_ctl.py" in cmd:
+            if is_in_herdr or is_broker_child or is_claude_helper_process(cmd) or "omarchy-agent-usage" in cmd or "__omp_worker" in cmd or "gateway run" in cmd or "serve --host" in cmd or "zygote" in cmd or "agent_ctl.py" in cmd:
                 continue
 
             # Check if this is a Hermes Desktop GUI process

--- a/agent_ctl.py
+++ b/agent_ctl.py
@@ -233,13 +233,21 @@ def is_hermes_cli_process(cmd: str) -> bool:
 # Claude Code runs internal helpers under the same `claude` binary (argv[0]).
 # They are identifiable by a literal subcommand verb in argv[1]; real sessions
 # are invoked as `claude --session-id …`, `claude --resume …` or bare `claude`,
-# where the second token is a flag or absent. (Ref: issue #10)
+# where that slot holds a flag, a prompt, or nothing. (Ref: issue #10)
 CLAUDE_HELPER_SUBCOMMANDS = ("daemon", "bg-pty-host", "bg-spare")
 
 
-def is_claude_helper_process(cmd: str) -> bool:
-    """True for Claude Code internal helper processes (daemon, bg-pty-host, bg-spare)."""
-    tokens = cmd.split()
+def is_claude_helper_process(cmd: str, argv: Optional[List[str]] = None) -> bool:
+    """Heuristic: True for Claude Code internal helpers (daemon, bg-pty-host, bg-spare).
+
+    Helpers share argv[0] == "claude" with real sessions but carry a literal
+    subcommand verb in argv[1]; real sessions have a flag, a prompt, or nothing
+    there. Pass the exact /proc argv list (get_process_info()["argv"]) so a
+    prompt whose first word is e.g. "daemon" — a single argv element — is not
+    mistaken for the verb; without argv, cmd.split() is used as a best-effort
+    approximation (exact token match, no substring/prefix matching).
+    """
+    tokens = list(argv) if argv is not None else cmd.split()
     if len(tokens) < 2 or os.path.basename(tokens[0]) != "claude":
         return False
     return tokens[1] in CLAUDE_HELPER_SUBCOMMANDS
@@ -255,7 +263,7 @@ def is_valid_agent_process(pid: int) -> bool:
     cmd = info["cmd"]
     tokens = cmd.split()
     first = os.path.basename(tokens[0]) if tokens else ""
-    if first in ("omp", "pi", "claude", "codex", "opencode", "cline", "cursor", "agy") and not is_claude_helper_process(cmd):
+    if first in ("omp", "pi", "claude", "codex", "opencode", "cline", "cursor", "agy") and not is_claude_helper_process(cmd, info.get("argv")):
         return True
     if first in ("python", "python3") and is_hermes_cli_process(cmd):
         return True
@@ -280,9 +288,14 @@ def get_process_info(pid: int) -> Optional[Dict[str, Any]]:
             ppid = int(fields[1])
             tty_nr = int(fields[4])
         with open(f"{proc_dir}/cmdline", "rb") as cf:
-            cmd = cf.read().decode("utf-8", errors="replace").replace("\x00", " ").strip()
+            raw_cmdline = cf.read().decode("utf-8", errors="replace")
+        # Exact argv elements (cmdline is NUL-separated). Empty string = zombie.
+        # `argv` preserves boundaries; `cmd` keeps the legacy space-joined form
+        # for substring checks (argv elements may themselves contain spaces).
+        argv = [a for a in raw_cmdline.split("\x00") if a != ""]
+        cmd = " ".join(argv).strip()
         cwd = os.path.realpath(f"{proc_dir}/cwd")
-        return {"pid": pid, "ppid": ppid, "tty": tty_nr, "state": state, "cmd": cmd, "cwd": cwd}
+        return {"pid": pid, "ppid": ppid, "tty": tty_nr, "state": state, "cmd": cmd, "cwd": cwd, "argv": argv}
     except Exception:
         return None
 
@@ -1288,7 +1301,7 @@ def scan_standalone_agents(herdr_server_pids: List[int], seen_cwds: Set[str], cl
             )
 
             # Skip anything running inside Herdr, spawned as an internal background worker, or system usage script
-            if is_in_herdr or is_broker_child or is_claude_helper_process(cmd) or "omarchy-agent-usage" in cmd or "__omp_worker" in cmd or "gateway run" in cmd or "serve --host" in cmd or "zygote" in cmd or "agent_ctl.py" in cmd:
+            if is_in_herdr or is_broker_child or is_claude_helper_process(cmd, info.get("argv")) or "omarchy-agent-usage" in cmd or "__omp_worker" in cmd or "gateway run" in cmd or "serve --host" in cmd or "zygote" in cmd or "agent_ctl.py" in cmd:
                 continue
 
             # Check if this is a Hermes Desktop GUI process


### PR DESCRIPTION
## Summary

Claude Code's internal helper processes (`claude daemon run`, `claude bg-pty-host`, `claude bg-spare`) share argv[0] with real sessions, so the panel showed **6 Claude agents when only 2 real sessions exist**. Helpers are now discriminated by their argv[1] subcommand verb and excluded from discovery; the same guard protects the kill gate.

## Changes

- Add `is_claude_helper_process()` — matches `argv[0] == claude` AND `argv[1] ∈ {daemon, bg-pty-host, bg-spare}`; exact token match, no substring matching (which would over-match paths and session titles)
- Wire into the `scan_standalone_agents` skip-list → helpers no longer rendered as agent cards
- Wire into `is_valid_agent_process` → `kill_target` refuses helper PIDs instead of SIGTERMing them
- `get_process_info` now preserves the exact `/proc/<pid>/cmdline` argv list (NUL-separated) alongside the legacy space-joined `cmd`, so a real session whose prompt is a single argv element (e.g. `claude "daemon status"`) is not misclassified — security-review finding, fixed and re-verified

## Screenshot

- [x] Infographic present: `infographic.png` (unchanged — behavior fix, no visual redesign)

## Security Review

- [x] Plan-level security review: SAFE (verdict + concerns recorded in plan)
- [x] Code quality review passed
- [x] Security audit passed after fix (1 medium finding — argv-boundary loss in flattened cmdline — fixed and re-verified)
- [x] QML/frontend specialist review passed (Panel.qml card model, pane_id formats, statuses, and manifest.json schema all unaffected)

## Testing

- [x] 15/15 string-fallback classification cases (the issue's 6 real command lines + edge cases: `claude-daemon run`, `node claude daemon run`, `claude --resume daemon`, `claude daemonize …`, `claude -p`, prompt-as-arg)
- [x] 9/9 live-process e2e: kill gate refuses `claude daemon run --origin transient`, admits + kills real-session shape
- [x] Security reviewer PoCs (`claude "daemon status check"`, multi-line prompt) classify as real sessions: 6/6
- [x] `scan_standalone_agents` run with a live helper process: no card emitted, remaining cards unchanged
- [x] `python3 -m py_compile agent_ctl.py` clean

Closes #10
