### PR TITLE
Report real Claude Code status via Claude Code hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,65 @@ omarchy plugin remove meviusisback.agent-orchestr
 
 Or manually remove the symlink/directory from `~/.config/omarchy/plugins/meviusisback.agent-orchestr` and remove `"meviusisback.agent-orchestr"` from `~/.config/omarchy/shell.json`.
 
+## Claude Code Status (optional)
+
+Claude Code doesn't keep a JSONL transcript file descriptor open the way OMP
+does, and it exposes no local session/socket API the way Hermes does. Without
+extra help, this plugin can only see that a `claude` process exists — it
+falls back to a generic `idle`/"Ready for prompt" for every Claude session,
+regardless of whether it's actually working, waiting on you, or done.
+
+To get real `working` / `waiting` / `completed` status for Claude Code,
+install the bundled hook script, which writes a small status file per
+session that `agent_ctl.py` reads (see `read_claude_hook_status()`):
+
+```bash
+mkdir -p ~/.claude/hooks
+cp hooks/claude-code-status.sh ~/.claude/hooks/
+chmod +x ~/.claude/hooks/claude-code-status.sh
+```
+
+Then merge this into your `~/.claude/settings.json` (merge the `PreToolUse`
+matcher alongside any existing entries — don't replace the array):
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": ".*",
+        "hooks": [{ "type": "command", "command": "~/.claude/hooks/claude-code-status.sh", "timeout": 5 }]
+      }
+    ],
+    "UserPromptSubmit": [
+      { "hooks": [{ "type": "command", "command": "~/.claude/hooks/claude-code-status.sh", "timeout": 5 }] }
+    ],
+    "Notification": [
+      { "hooks": [{ "type": "command", "command": "~/.claude/hooks/claude-code-status.sh", "timeout": 5 }] }
+    ],
+    "Stop": [
+      { "hooks": [{ "type": "command", "command": "~/.claude/hooks/claude-code-status.sh", "timeout": 5 }] }
+    ],
+    "SubagentStop": [
+      { "hooks": [{ "type": "command", "command": "~/.claude/hooks/claude-code-status.sh", "timeout": 5 }] }
+    ],
+    "SessionEnd": [
+      { "hooks": [{ "type": "command", "command": "~/.claude/hooks/claude-code-status.sh", "timeout": 5 }] }
+    ]
+  }
+}
+```
+
+The script keys each status file by the actual `claude` process's PID (walking
+up `/proc` ancestry from the hook's own `$PPID`, since the hook runs as a child
+process, not as `claude` itself), matching how `agent_ctl.py` already identifies
+Claude sessions — `cwd` alone would not, since concurrent sessions can share a
+working directory. Files are removed on `SessionEnd`, and any left behind by a
+session that was `SIGKILL`ed are pruned on the next one.
+
+Installing the hook is purely additive: without it, Claude Code sessions behave
+exactly as they do today (generic idle fallback).
+
 ## Keybinding
 
 You can toggle the popup panel with a global Hyprland keyboard shortcut.
@@ -97,6 +156,7 @@ omarchy shell meviusisback.agent-orchestr refresh
 - **Zero Network Transmission**: All agent tracking and process inspection runs 100% locally on your machine.
 - **Automatic Secret Redaction**: Prompts and status lines automatically redact API keys (OpenAI, Anthropic, OpenRouter, Groq), GitHub tokens, AWS keys, and Bearer tokens before UI rendering or IPC output.
 - **Read-Only SQLite & Session Parsing**: Hermes databases are queried strictly with `?mode=ro`, and OMP transcripts are parsed in read-only mode.
+- **Validated Hook Input**: Claude Code status files are trusted only when they carry a known status value and a fresh timestamp, and their detail line passes through the same redaction as every other agent detail.
 - **Safe Process Signaling**: Process termination verifies the target PID against active AI agent process signatures before signaling.
 - **Shell & Injection Safety**: All subprocess and Hyprland dispatch operations use discrete argument vectors without shell evaluation, and QML Text components enforce plain-text formatting.
 - **Plain-Text Convention**: Every `Text` element in `Panel.qml` must declare `textFormat: Text.PlainText` explicitly — agent-supplied strings (titles, labels, paths) must never render through QML's default `AutoText`, which would interpret rich-text markup as shell UI. New widgets should preserve this invariant.

--- a/agent_ctl.py
+++ b/agent_ctl.py
@@ -23,6 +23,16 @@ HERDR_SOCK_PATH = os.path.expanduser(os.environ.get("HERDR_SOCKET_PATH", "~/.con
 OMP_SESSIONS_DIR = os.path.expanduser("~/.omp/agent/sessions")
 HERMES_STATE_DB = os.path.expanduser("~/.hermes/state.db")
 
+# Claude Code keeps no session .jsonl file descriptor open the way OMP does and
+# exposes no local session API the way Hermes does, so find_session_for_process()
+# never resolves a session for it and every claude process falls back to the
+# generic idle default regardless of its real state. Claude Code hooks (see
+# hooks/claude-code-status.sh) write real status here instead, one file per
+# session, keyed by the claude process's own PID.
+CLAUDE_HOOK_STATUS_DIR = os.path.expanduser("~/.local/state/omarchy/agents/claude-status")
+CLAUDE_HOOK_STATUS_MAX_AGE = 24 * 3600
+CLAUDE_HOOK_STATUSES = ("working", "waiting", "completed", "idle")
+
 KNOWN_TERMINALS = (
     "foot", "ghostty", "alacritty", "kitty", "wezterm", "gnome-terminal",
     "ptyxis", "konsole", "terminator", "xfce4-terminal", "xterm", "rio",
@@ -361,6 +371,35 @@ def get_process_open_session(pid: int) -> Optional[str]:
     except Exception:
         pass
     return None
+
+
+# Only a status from the known vocabulary carrying a fresh timestamp is trusted,
+# so a malformed, foreign or stale file can never reach the UI. Freshness matters
+# because a session killed with SIGKILL never fires SessionEnd, and its last
+# "working" would otherwise stick around forever. The detail line is
+# hook-supplied free text (a tool name, a permission prompt), so it runs through
+# the same first-line and secret-redaction pass as every other agent detail.
+def read_claude_hook_status(pid: int) -> Optional[Dict[str, str]]:
+    """Read the live status Claude Code's own hooks wrote for this PID."""
+    path = os.path.join(CLAUDE_HOOK_STATUS_DIR, f"{pid}.json")
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception:
+        return None
+    if not isinstance(data, dict):
+        return None
+    status = data.get("status")
+    if status not in CLAUDE_HOOK_STATUSES:
+        return None
+    updated = data.get("updated")
+    if not isinstance(updated, (int, float)) or (time.time() - updated) > CLAUDE_HOOK_STATUS_MAX_AGE:
+        return None
+    detail = data.get("detail")
+    return {
+        "status": status,
+        "detail": extract_first_line(clean_ansi(detail)) if isinstance(detail, str) else "",
+    }
 
 
 def find_session_for_process(agent_type: str, pid: int, cwd: str, claimed_sessions: Set[str]) -> Optional[str]:
@@ -1381,14 +1420,22 @@ def scan_standalone_agents(herdr_server_pids: List[int], seen_cwds: Set[str], cl
                 workspace_name = f"Desktop {ws_id}"
                 tab_name = f"{term_name.capitalize()} (Desktop {ws_id})"
                 pane_id = f"terminal:addr:{window_addr}"
-                session_path = find_session_for_process(agent_type, pid, cwd, claimed_sessions)
+                # A hook-reported Claude status is authoritative: it comes from
+                # the session itself, so it wins over transcript inference and
+                # over the process-state guess further down.
+                claude_hook_status = read_claude_hook_status(pid) if agent_type == "claude" else None
+                session_path = None if claude_hook_status else find_session_for_process(agent_type, pid, cwd, claimed_sessions)
                 user_goal = None
                 detail_text = None
                 model_name = None
                 status_override = None
                 has_question = False
 
-                if session_path:
+                if claude_hook_status:
+                    status_override = claude_hook_status["status"]
+                    detail_text = claude_hook_status["detail"] or "Ready for prompt"
+                    has_question = status_override == "waiting"
+                elif session_path:
                     claimed_sessions.add(session_path)
                     if agent_type == "omp":
                         if os.path.exists(session_path):

--- a/hooks/claude-code-status.sh
+++ b/hooks/claude-code-status.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# Writes a live status file per Claude Code session for this plugin to
+# consume for agent_type == "claude" (see read_claude_hook_status() in
+# agent_ctl.py). Claude Code keeps no JSONL fd open the way OMP does and
+# exposes no local session API the way Hermes does, so without this the
+# plugin can only see that a `claude` process exists, never its actual
+# working/waiting/completed state.
+#
+# Install: register this script in ~/.claude/settings.json under the hook
+# events handled below (see README for the exact JSON), then `chmod +x` it.
+set -uo pipefail
+
+STATE_DIR="$HOME/.local/state/omarchy/agents/claude-status"
+mkdir -p "$STATE_DIR" || exit 0
+
+input="$(cat)"
+
+get() { printf '%s' "$input" | jq -r "$1 // empty" 2>/dev/null; }
+
+event="$(get '.hook_event_name')"
+cwd="$(get '.cwd')"
+tool_name="$(get '.tool_name')"
+message="$(get '.message')"
+
+# argv[0]'s basename, the way agent_ctl.py itself identifies a claude
+# process. /proc/<pid>/comm can be the wrapper binary (node) instead.
+proc_argv0_name() {
+  local argv0=""
+  IFS= read -r -d '' argv0 < "/proc/$1/cmdline" 2>/dev/null
+  [ -n "$argv0" ] && printf '%s' "${argv0##*/}"
+}
+
+# The hook runs as a child process of the claude CLI (not as claude itself),
+# so walk up /proc ancestry to find the actual claude PID the plugin's /proc
+# scan will see. cwd alone isn't a usable key: multiple concurrent sessions
+# can share a working directory.
+find_claude_pid() {
+  local pid="$PPID"
+  local depth=0
+  while [ -n "$pid" ] && [ "$pid" != "0" ] && [ "$pid" != "1" ] && [ "$depth" -lt 10 ]; do
+    if [ "$(proc_argv0_name "$pid")" = "claude" ] || [ "$(cat "/proc/$pid/comm" 2>/dev/null)" = "claude" ]; then
+      printf '%s' "$pid"
+      return 0
+    fi
+    local ppid
+    ppid="$(awk '$1=="PPid:"{print $2}' "/proc/$pid/status" 2>/dev/null)"
+    [ -z "$ppid" ] && break
+    pid="$ppid"
+    depth=$((depth + 1))
+  done
+  return 1
+}
+
+# Drop files whose session died without firing SessionEnd (SIGKILL, crash).
+# Keeps the directory bounded and stops a dead PID's last status from being
+# read back if the kernel recycles that PID onto a new claude process.
+prune_dead_sessions() {
+  local f pid
+  for f in "$STATE_DIR"/*.json; do
+    [ -e "$f" ] || continue
+    pid="$(basename "$f" .json)"
+    case "$pid" in
+      *[!0-9]*) continue ;;
+    esac
+    [ -d "/proc/$pid" ] || rm -f "$f"
+  done
+}
+
+claude_pid="$(find_claude_pid)" || exit 0
+
+status_file="$STATE_DIR/${claude_pid}.json"
+
+case "$event" in
+  UserPromptSubmit)
+    status="working"; detail="Processing prompt" ;;
+  PreToolUse)
+    status="working"; detail="Running: ${tool_name:-tool}" ;;
+  Notification)
+    status="waiting"; detail="${message:-Needs your input}" ;;
+  Stop|SubagentStop)
+    status="completed"; detail="Ready for prompt" ;;
+  SessionEnd)
+    rm -f "$status_file"
+    prune_dead_sessions
+    exit 0 ;;
+  *)
+    exit 0 ;;
+esac
+
+# Written via a temp file so the plugin, which polls concurrently, never
+# reads a half-written JSON document.
+tmp_file="$(mktemp "${status_file}.XXXXXX")" || exit 0
+jq -n \
+  --arg status "$status" \
+  --arg detail "$detail" \
+  --arg cwd "$cwd" \
+  --argjson updated "$(date +%s)" \
+  '{status: $status, detail: $detail, cwd: $cwd, updated: $updated}' \
+  > "$tmp_file" && mv "$tmp_file" "$status_file" || rm -f "$tmp_file"
+
+exit 0


### PR DESCRIPTION
## Problem

Every Claude Code session shows up as `idle` / "Ready for prompt", whatever it is actually doing.

`find_session_for_process()` can resolve a session for OMP (open `.jsonl` fd) and Hermes (local state DB), but Claude Code offers neither — it keeps no transcript file descriptor open and exposes no local session API. So a `claude` process always falls through to the generic fallback, and the process-state guess behind it (`state in ("R", "D")`) never helps either: the CLI sits in `S` (sleeping) even mid-turn, waiting on the network.

Result: the `Working` / `Waiting` filter tabs and the bar badge stay empty for Claude users, which is exactly the case where "is it waiting on me?" matters most.

## Approach

Claude Code can report its own state through its hooks system, so this lets it do that instead of guessing.

- `hooks/claude-code-status.sh` (new, opt-in) writes one small status file per session under `~/.local/state/omarchy/agents/claude-status`, on `UserPromptSubmit`, `PreToolUse`, `Notification`, `Stop` / `SubagentStop` and `SessionEnd`.
- `agent_ctl.py` gains `read_claude_hook_status()`, and for `agent_type == "claude"` prefers that status over transcript inference.

Files are keyed by the `claude` process's own PID (the hook walks up `/proc` ancestry from its `$PPID`, since it runs as a child, not as `claude` itself) so they line up with the existing `/proc` scan. `cwd` would not work as the key — concurrent sessions can share a working directory.

## Safety

Kept in line with the repo's existing invariants:

- Only a status from a fixed vocabulary (`working` / `waiting` / `completed` / `idle`) with a fresh timestamp is trusted; a malformed, foreign or stale file is ignored entirely.
- The hook-supplied detail line (a tool name, a permission-prompt message) passes through the same `clean_ansi()` + `extract_first_line()` + `redact_secrets()` path as every other agent detail, so it is single-line, length-capped and redacted before it reaches the UI.
- Status files are removed on `SessionEnd`; one left behind by a `SIGKILL`ed session is pruned on the next session's end, and the freshness check keeps it out of the UI in the meantime.
- The hook writes through `mktemp` + `mv`, so the concurrently polling collector never reads a half-written document.

## Compatibility

Entirely opt-in and additive. Without the hook installed, Claude sessions behave exactly as they do today. Nothing changes for Herdr, OMP, Hermes, Orca or any other agent path. README documents the install in a new "Claude Code Status (optional)" section.

## Testing

Verified on Omarchy / Hyprland with three concurrent Claude Code sessions (two sharing a `cwd`): they now report `working`, `completed` and `idle` distinctly, and a permission prompt flips the session to `waiting` and lights up the bar badge. `read_claude_hook_status()` was also exercised directly against malformed, non-dict, unknown-status, stale, missing-timestamp, multi-line-detail and secret-bearing files — each rejected or sanitized as intended.