### PR TITLE
fix(security): add owner and symlink checks for Claude hook status dir (Hancore #5864)

### DIFF
--- a/agent_ctl.py
+++ b/agent_ctl.py
@@ -382,6 +382,32 @@ def get_process_open_session(pid: int) -> Optional[str]:
 def read_claude_hook_status(pid: int) -> Optional[Dict[str, str]]:
     """Read the live status Claude Code's own hooks wrote for this PID."""
     path = os.path.join(CLAUDE_HOOK_STATUS_DIR, f"{pid}.json")
+
+    # Owner and symlink checks: verify the directory is not a symlink, is owned
+    # by the current user, and that none of its ancestor directories are symlinks.
+    try:
+        if os.path.islink(CLAUDE_HOOK_STATUS_DIR):
+            return None
+        if os.stat(CLAUDE_HOOK_STATUS_DIR).st_uid != os.getuid():
+            return None
+        # Check ancestors for symlinks
+        check_dir = CLAUDE_HOOK_STATUS_DIR
+        while check_dir != os.path.expanduser("~") and check_dir != "/":
+            parent = os.path.dirname(check_dir)
+            if os.path.islink(parent):
+                return None
+            try:
+                if os.stat(parent).st_uid != os.getuid():
+                    return None
+            except Exception:
+                return None
+            check_dir = parent
+        # Verify the file itself is not a symlink
+        if os.path.islink(path):
+            return None
+    except Exception:
+        return None
+
     try:
         with open(path, "r", encoding="utf-8") as f:
             data = json.load(f)

--- a/hooks/claude-code-status.sh
+++ b/hooks/claude-code-status.sh
@@ -11,7 +11,49 @@
 set -uo pipefail
 
 STATE_DIR="$HOME/.local/state/omarchy/agents/claude-status"
+
+# ── Owner and symlink checks ─────────────────────────────────────────────────
+# Verify the status directory (and all ancestors) are owned by the current user
+# and are not symlinks. This prevents an attacker from creating a symlink at a
+# parent path and redirecting our writes to an arbitrary location.
+validate_path() {
+  local check_path="$1"
+  local owner_now
+  owner_now="$(stat -c '%U' "$check_path" 2>/dev/null)" || exit 1
+  if [ "$owner_now" != "$(id -un)" ]; then
+    # Directory is owned by someone else — refuse to use it
+    return 1
+  fi
+  if [ -L "$check_path" ]; then
+    # Directory is a symlink — refuse to use it
+    return 1
+  fi
+  return 0
+}
+
+# Also validate that ancestor paths are not symlinks
+validate_ancestors() {
+  local dir="$1"
+  local current="$dir"
+  while [ "$current" != "/" ] && [ "$current" != "$HOME" ]; do
+    current="$(dirname "$current")"
+    if [ -L "$current" ]; then
+      return 1
+    fi
+    local owner_now
+    owner_now="$(stat -c '%U' "$current" 2>/dev/null)" || return 1
+    if [ "$owner_now" != "$(id -un)" ]; then
+      return 1
+    fi
+  done
+  return 0
+}
+
 mkdir -p "$STATE_DIR" || exit 0
+# Validate the status directory
+if ! validate_path "$STATE_DIR" || ! validate_ancestors "$STATE_DIR"; then
+  exit 0
+fi
 
 input="$(cat)"
 
@@ -89,6 +131,10 @@ esac
 
 # Written via a temp file so the plugin, which polls concurrently, never
 # reads a half-written JSON document.
+# Validate that the status file is not a symlink before overwriting it.
+if [ -L "$status_file" ]; then
+  rm -f "$status_file"
+fi
 tmp_file="$(mktemp "${status_file}.XXXXXX")" || exit 0
 jq -n \
   --arg status "$status" \


### PR DESCRIPTION
## Summary

This fixes Hancore's blocking finding from marketplace issue #5864: the Claude hook follows an unchecked `~/.local/state/omarchy/agents/claude-status` path and publishes status files without owner or ancestor-symlink checks.

## Changes

- **`hooks/claude-code-status.sh`**: Added `validate_path()` and `validate_ancestors()` functions that:
  - Verify the status directory is owned by the current user
  - Verify the status directory is not a symlink
  - Verify all ancestor directories (up to `$HOME`) are not symlinks and owned by the current user
  - Verify the target status file is not a symlink before writing

- **`agent_ctl.py`**: Updated `read_claude_hook_status()` to:
  - Verify the status directory is not a symlink and is owned by the current user
  - Check all ancestor directories for symlinks and ownership
  - Verify the status file itself is not a symlink before reading

## Security

This prevents an attacker from:
1. Creating a symlink at a parent path (e.g., `~/.local/state/omarchy/agents`)
2. Creating a symlink for the status directory itself
3. Creating a symlink for a status file

All of which could redirect status writes/reads to an arbitrary location.

See: https://github.com/omacom/omarchy-plugin-marketplace/issues/5864