### PR TITLE
fix(grok): harden session discovery, guard reads, bound payload, add tests

### DIFF
--- a/Model.js
+++ b/Model.js
@@ -107,12 +107,13 @@ function agentDisplayName(agent) {
   if (a === "claude") return "Claude"
   if (a === "codex") return "Codex"
   if (a === "opencode") return "OpenCode"
+  if (a === "grok") return "Grok"
   return a ? a.charAt(0).toUpperCase() + a.slice(1) : "Agent"
 }
 
 function agentIconPath(agent) {
   var a = String(agent || "").toLowerCase()
-  var known = ["omp", "hermes", "herdr", "claude", "codex", "opencode"]
+  var known = ["omp", "hermes", "herdr", "claude", "codex", "opencode", "grok"]
   if (known.indexOf(a) >= 0) {
     return "assets/icons/" + a + ".svg"
   }
@@ -127,13 +128,16 @@ function truncateText(text, maxLen) {
   return str.slice(0, limit - 1).trim() + "…"
 }
 
-function formatBarHeadline(summary, displayMode, maxLen) {
+function formatBarHeadline(summary, displayMode, maxLen, hideTask) {
   if (!summary) return "Agents"
   var total = Number(summary.total) || 0
   var working = Number(summary.working) || 0
   var waiting = Number(summary.waiting) || 0
   var completed = Number(summary.completed) || 0
-  var mode = String(displayMode || "Icon").toLowerCase()
+  // hideTask (privacyHidePrompts): the headline string is agent-supplied task
+  // text, so it is never rendered when the user asked for prompts to be hidden —
+  // falls through to the counts-only form below.
+  var mode = hideTask ? "compact" : String(displayMode || "Icon").toLowerCase()
 
   if (mode === "compact") {
     if (waiting > 0) return total + " ag · " + waiting + " prompt"

--- a/Panel.qml
+++ b/Panel.qml
@@ -30,6 +30,10 @@ Panel {
   readonly property string barDisplay: String(root.setting("barDisplay", "Icon"))
   readonly property bool showIdleInBar: Boolean(root.setting("showIdleInBar", false))
   readonly property int maxTaskLength: Math.max(20, Number(root.setting("maxTaskLength", 45)) || 45)
+  // Privacy option for screen-sharing: when on, no agent-supplied prompt/task
+  // text is rendered anywhere in the widget (bar ticker or card), only counts,
+  // status words and the repo breadcrumb. The collector still returns the text.
+  readonly property bool privacyHidePrompts: Boolean(root.setting("privacyHidePrompts", false))
 
   readonly property bool barShowsText: barDisplay.toLowerCase() === "status" || barDisplay.toLowerCase() === "compact"
 
@@ -122,10 +126,12 @@ Panel {
   // Background processes
   Process {
     id: fetchProc
-    // head -c bounds the stream structurally: after 256 KiB head exits and
-    // SIGPIPE stops the helper, so the collector below can never accumulate
-    // more than the cap regardless of helper output size.
-    command: ["sh", "-c", "python3 '" + root.scriptPath() + "' status | head -c 262144"]
+    // The payload is bounded inside agent_ctl.py (dump_status_json: agent cap
+    // plus a hard byte ceiling) rather than by `python3 … | head -c`, so the
+    // collector itself is Quickshell's direct child. That matters for the stall
+    // timer below: terminating the process only signals the direct child, and a
+    // shell wrapper would leave the real collector running and leaked.
+    command: ["python3", root.scriptPath(), "status"]
     stdout: StdioCollector {
       waitForEnd: true
       onStreamFinished: {
@@ -145,6 +151,24 @@ Panel {
     stderr: StdioCollector {
       waitForEnd: true
       onStreamFinished: root.loading = false
+    }
+  }
+
+  // A collector tick that wedges (an unreadable or odd file in some agent's
+  // session tree is the realistic case) must not leave the widget stuck on
+  // "Loading…" forever: fetchStatus() no-ops while fetchProc.running, so a
+  // Process that never exits can't be re-run. Give up on one that overstays,
+  // exactly as the shell's own widgets do, and keep trying on the next tick.
+  Timer {
+    id: fetchStallTimer
+    interval: 18000
+    running: fetchProc.running
+    repeat: true
+    onTriggered: {
+      if (fetchProc.running) {
+        fetchProc.running = false
+        root.loading = false
+      }
     }
   }
 
@@ -280,7 +304,7 @@ Panel {
 
       Text {
         id: chipLabel
-        text: Model.formatBarHeadline(root.summary, root.barDisplay, root.maxTaskLength)
+        text: Model.formatBarHeadline(root.summary, root.barDisplay, root.maxTaskLength, root.privacyHidePrompts)
         textFormat: Text.PlainText
         font.family: root.fontFamily
         font.pixelSize: Style.font.caption || Style.space(11)
@@ -665,7 +689,7 @@ Panel {
               // Task Title
               Text {
                 Layout.fillWidth: true
-                text: modelData.title || "Active agent session"
+                text: root.privacyHidePrompts ? "Session details hidden" : (modelData.title || "Active agent session")
                 textFormat: Text.PlainText
                 font.family: root.fontFamily
                 font.pixelSize: Style.font.caption
@@ -678,7 +702,7 @@ Panel {
 
               // Activity Detail (if running tool, prompt question, or concluding tail)
               Text {
-                visible: Boolean(modelData.detail) && modelData.detail !== modelData.title
+                visible: !root.privacyHidePrompts && Boolean(modelData.detail) && modelData.detail !== modelData.title
                 Layout.fillWidth: true
                 text: modelData.detail || ""
                 textFormat: Text.PlainText
@@ -729,10 +753,14 @@ Panel {
                   }
                 }
 
-                // Workspace & Tab Location
+                // Workspace & Tab Location. With privacyHidePrompts on, only the
+                // workspace name is shown: tab and pane labels can carry the
+                // task text too (Orca renames its tab to "<task> · <model>"), so
+                // they are task text and must be hidden like the title.
                 Text {
                   Layout.fillWidth: true
                   text: {
+                    if (root.privacyHidePrompts) return modelData.workspace || ""
                     var parts = []
                     if (modelData.workspace) parts.push(modelData.workspace)
                     if (modelData.tab) parts.push(modelData.tab)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Agent Orchestrator for Omarchy
 
-Real-time status, active tasks, and one-click workspace switching for AI coding agents (**Herdr**, **OMP**, **Hermes**, **Claude**, **Codex**, **OpenCode**, **Agy** (Antigravity CLI)) in the Omarchy bar.
+Real-time status, active tasks, and one-click workspace switching for AI coding agents (**Herdr**, **OMP**, **Hermes**, **Claude**, **Codex**, **OpenCode**, **Agy** (Antigravity CLI), **Grok**) in the Omarchy bar.
 
 ![Agent Orchestrator](preview.png)
 
 ## Features
 
-- **Live Multi-Source Agent Tracking**: Seamlessly tracks AI coding agents across **Herdr** daemon panes (`~/.config/herdr/herdr.sock`), standalone terminal windows (Ghostty, Foot, Kitty, Alacritty, WezTerm), **OMP** sessions (`~/.omp/agent/sessions/`), and **Hermes** CLI & Desktop app databases (`~/.hermes/state.db`).
+- **Live Multi-Source Agent Tracking**: Seamlessly tracks AI coding agents across **Herdr** daemon panes (`~/.config/herdr/herdr.sock`), standalone terminal windows (Ghostty, Foot, Kitty, Alacritty, WezTerm), **OMP** sessions (`~/.omp/agent/sessions/`), **Hermes** CLI & Desktop app databases (`~/.hermes/state.db`), and **Grok** Build TUI sessions (`$GROK_HOME/active_sessions.json` + `events.jsonl`).
 - **One-Click Workspace & Window Switching**: Click any agent card to switch Hyprland workspaces and focus the exact terminal window, Herdr pane, or Hermes Desktop window.
 - **Visual Status Bar Display**:
   - **`Icon` Mode**: Agent orchestrator glyph with dynamic activity badge and spinner animation when agents are actively working.
@@ -118,6 +118,83 @@ session that was `SIGKILL`ed are pruned on the next one.
 Installing the hook is purely additive: without it, Claude Code sessions behave
 exactly as they do today (generic idle fallback).
 
+## Grok Build TUI
+
+Grok already writes a live roster (`$GROK_HOME/active_sessions.json`, default
+`~/.grok`) and a status event stream (`events.jsonl`) per session. The collector
+reads those files directly — no hook install is required.
+
+Interactive sessions are `grok`, `grok --resume …`, `grok --session-id …`, or
+`grok "<prompt>"`. CLI verbs (`grok login`, `grok mcp`, `grok agent`,
+`grok doctor`, …) share the same binary and are skipped by an exact `argv[1]`
+match, the same way Claude Code helpers are. **Headless and info-only
+invocations are not sessions either** — `grok -p/--single`, `--prompt-file`,
+`--prompt-json`, `--output-format`, `--json-schema`, `-v/--version`,
+`-h/--help` and `--show-current` are recognised by exact token anywhere in the
+argument list, so a one-shot run never produces a card. The mise
+`node …/bin/grok` wrapper is not counted: its `argv[0]` is `node`. Forked
+`subagent*` sessions are skipped so the parent card is not doubled.
+
+A live session is resolved from the roster by **PID**, then by its session id,
+and only as a last resort by working directory — the session id is the reliable
+key, so concurrent sessions in one directory stay distinct and the layout Grok
+uses for very long paths (a slug+hash group with the real path in a `.cwd`
+marker file, used when the URL-encoded directory name exceeds 255 bytes) is
+found without guessing its name. The deterministic encoded group name is always
+preferred: a `.cwd` marker is local file content, so a group that merely *claims*
+a working directory can never outrank the real one, nor spend the budget the real
+card's summary and event reads need. When an invocation passes `--cwd`, the
+process working directory is ignored and the session's own directory is shown. A
+session that cannot be resolved gets no card rather than a wrong one; the cwd
+fallback is the one place where a session the roster has not recorded can be
+attributed by recency instead, which is why it needs the process-start window and
+never reuses a session another card already claimed.
+
+Status mapping: `streaming_*` / `tool_execution` → `working`; `permission_prompt`
+and an unanswered `permission_requested` → `waiting`; `turn_ended` →
+`completed`; otherwise `idle`. Events are folded in log order, so the newest
+event decides: a tool that started after a permission prompt reads as
+`working`, and a `permission_prompt` phase left behind by an auto-allowed ask is
+cleared by its `permission_resolved`.
+
+Everything read under `$GROK_HOME` goes through one guarded reader: it refuses
+symlinked, foreign-owned or group/world-writable paths, opens files with
+`O_NOFOLLOW | O_NONBLOCK`, and verifies the opened file descriptor (owner,
+regular file, single hard link, size cap, containment in `$GROK_HOME`) before
+reading. It caps each file and the total work per refresh cycle, memoizes parsed
+JSON, the group list and the group → `.cwd` mapping for the cycle, and widens a
+JSONL tail when the window would otherwise start inside a line — the newest
+events decide the status, so a large-but-valid event must not be lost. Every
+string it returns is treated as untrusted UI text through the same secret
+redaction as the rest of the plugin: prompts, titles, event tool names, the model
+id, and the `.cwd` marker (accepted only when it actually looks like an absolute
+path). A malformed, half-written, oversized, hard-linked or planted file
+therefore degrades to "no detail" instead of a wrong card, a hang or a read
+outside the Grok data directory. The panel also runs the collector as a direct
+child (no shell pipeline) and aborts a tick that overstays, so a wedged helper
+can neither disable refresh nor be left behind.
+
+> Known limits (honest, not aspirational): the exact byte-for-byte encoding Grok
+> uses for group names has not been captured on a live session, so cwd-only
+> resolution (used for Orca/Herdr panes, which have no PID) relies on the
+> documented URL-encoding plus the `.cwd` marker; the `session_kind` values that
+> mark subagent sessions are likewise taken from the documented layout. Both
+> degrade to a missing card, never a wrong one — and PID-resolved sessions do
+> not depend on either. The cwd-only fallback cannot bind a session to a process:
+> it considers at most 32 `.cwd`-claiming groups and the 32 newest sessions in
+> each, ranked by recency, so the newest session in that directory is what an
+> Orca/Herdr card shows and a locally planted newer session there would win that
+> card (PID-resolved cards never look at markers). A single event line larger than
+> 512 KiB is still skipped
+> (the window stops widening there), and the per-cycle budget is a bound on work,
+> not a promise that every card is enriched when a tree is pathological. The path
+> guard reads POSIX mode bits, so a directory whose write access comes only from
+> an ACL is not detected (Grok's own tree is 0755/0644 by default); the descriptor
+> containment check needs `/proc`, making Grok enrichment Linux-only; and the
+> ancestor-path check cannot fully close a TOCTOU race without an `openat` chain.
+> The plugin is a local read-only collector, so those residuals are accepted
+> rather than claimed fixed.
+
 ## Keybinding
 
 You can toggle the popup panel with a global Hyprland keyboard shortcut.
@@ -149,7 +226,18 @@ omarchy shell meviusisback.agent-orchestr refresh
 | `refreshIntervalSec` | `3` | Polling frequency in seconds |
 | `showIdleInBar` | `false` | Whether to display badge count when all agents are idle |
 | `maxTaskLength` | `45` | Maximum characters shown in the bar status ticker |
+| `privacyHidePrompts` | `false` | Hide agent-supplied prompt and task text in the bar and cards (counts, status, repo and workspace only) — for screen sharing and recordings |
 
+
+## Tests
+
+`agent_ctl.py` ships a hermetic fixture suite for the Grok collector. It points
+`GROK_HOME` at a temporary directory, touches no network, no `hyprctl`, no Orca
+and no real `~/.grok`, and never runs a full `fetch_all_agents()` cycle:
+
+```bash
+python3 tests/test_grok_sessions.py
+```
 
 ## Security & Privacy
 
@@ -157,8 +245,11 @@ omarchy shell meviusisback.agent-orchestr refresh
 - **Automatic Secret Redaction**: Prompts and status lines automatically redact API keys (OpenAI, Anthropic, OpenRouter, Groq), GitHub tokens, AWS keys, and Bearer tokens before UI rendering or IPC output.
 - **Read-Only SQLite & Session Parsing**: Hermes databases are queried strictly with `?mode=ro`, and OMP transcripts are parsed in read-only mode.
 - **Validated Hook Input**: Claude Code status files are trusted only when they carry a known status value and a fresh timestamp, and their detail line passes through the same redaction as every other agent detail.
+- **Guarded Grok Session Reads**: Everything read under `$GROK_HOME` is refused unless the whole path chain is user-owned, not a symlink and not group/world-writable; files are opened with `O_NOFOLLOW | O_NONBLOCK` (so a planted FIFO cannot block the collector) and the opened descriptor is re-verified — owner, regular file, single hard link, size, containment — before any bytes are read. Session ids from `active_sessions.json` are validated as UUIDs before they are used in a path, event-supplied detail text passes through the same redaction as every other detail, per-file sizes and total work per refresh cycle are capped, and anything that fails degrades to *no card* rather than a wrong one.
+- **Prompt Hiding Option**: `privacyHidePrompts` keeps agent-supplied prompt and task text out of the bar ticker and the cards entirely — including tab/pane labels, which can carry task text — leaving counts, status, repo path and workspace name. Secret redaction stays on regardless.
 - **Safe Process Signaling**: Process termination verifies the target PID against active AI agent process signatures before signaling.
-- **Shell & Injection Safety**: All subprocess and Hyprland dispatch operations use discrete argument vectors without shell evaluation, and QML Text components enforce plain-text formatting.
+- **Shell & Injection Safety**: All subprocess and Hyprland dispatch operations use discrete argument vectors without shell evaluation (the status refresh execs the collector directly, with the payload bounded inside it rather than by a shell pipeline), and QML Text components enforce plain-text formatting.
+- **Bounded Status Payload**: the collector caps the number of agent cards and the serialized reply size, so a pathological machine cannot make the widget's stdio collector accumulate unbounded output.
 - **Plain-Text Convention**: Every `Text` element in `Panel.qml` must declare `textFormat: Text.PlainText` explicitly — agent-supplied strings (titles, labels, paths) must never render through QML's default `AutoText`, which would interpret rich-text markup as shell UI. New widgets should preserve this invariant.
 ## License
 

--- a/agent_ctl.py
+++ b/agent_ctl.py
@@ -5,6 +5,7 @@ Discovers and manages AI agents across:
 1. Herdr workspaces & panes (Herdr daemon socket + process tree correlation)
 2. Standard terminal windows (Foot, Alacritty, Kitty, Ghostty)
 3. Hermes Desktop GUI instances (Electron app)
+4. Grok Build TUI sessions ($GROK_HOME/active_sessions.json + events.jsonl)
 """
 
 import glob
@@ -14,10 +15,12 @@ import re
 import signal
 import socket
 import sqlite3
+import stat
 import subprocess
 import sys
 import time
 from typing import Any, Dict, List, Optional, Set, Tuple
+from urllib.parse import quote, unquote
 
 HERDR_SOCK_PATH = os.path.expanduser(os.environ.get("HERDR_SOCKET_PATH", "~/.config/herdr/herdr.sock"))
 OMP_SESSIONS_DIR = os.path.expanduser("~/.omp/agent/sessions")
@@ -88,7 +91,9 @@ def clean_model_name(model_str: Optional[str]) -> str:
     m = str(model_str).strip()
     if "/" in m:
         parts = m.split("/")
-        if parts[0] in ("google-antigravity", "openrouter", "anthropic", "openai", "deepseek", "groq", "together"):
+        # Provider prefixes that only add noise to a small badge. `xai` is Grok's
+        # own provider id, and Grok session summaries may carry it.
+        if parts[0] in ("google-antigravity", "openrouter", "anthropic", "openai", "deepseek", "groq", "together", "xai"):
             m = "/".join(parts[1:])
     return m
 
@@ -263,6 +268,874 @@ def is_claude_helper_process(cmd: str, argv: Optional[List[str]] = None) -> bool
     return tokens[1] in CLAUDE_HELPER_SUBCOMMANDS
 
 
+# Grok Build's interactive TUI is argv[0] == "grok" with a flag, a prompt, or
+# nothing in argv[1]. The same binary also hosts one-shot CLI verbs (login,
+# mcp, doctor, agent, …) and headless single-turn runs (`grok -p …`).
+# Discriminate on exact argv tokens the same way Claude helpers are
+# (issue #10 / PR #11): a prompt whose first word is "agent" is a single argv
+# element and must not be mistaken for `grok agent`.
+GROK_HELPER_SUBCOMMANDS = (
+    "agent", "clone", "completions", "dashboard", "doctor", "du", "disk-usage",
+    "export", "help", "inspect", "leader", "login", "logout", "mcp", "memory",
+    "models", "plugin", "sessions", "setup", "trace", "update", "usage",
+    "version", "v", "worktree", "wrap",
+)
+# Tokens that mark a non-interactive invocation: headless single-turn runs and
+# info-only flags. They are matched anywhere in argv (a `grok --model x -p "…"`
+# run is still not a TUI session), which costs us a prompt that is *exactly*
+# one of these tokens — the same tradeoff the Claude helper filter accepts, and
+# it fails in the safe direction (no card beats a wrong card).
+GROK_NON_INTERACTIVE_FLAGS = (
+    "-p", "--single", "--prompt-file", "--prompt-json", "--output-format",
+    "--json-schema", "-v", "--version", "-h", "--help", "--show-current",
+)
+GROK_ARG_SCAN_LIMIT = 64            # argv elements inspected when classifying
+GROK_SESSION_ID_RE = re.compile(r"\A[0-9a-fA-F-]{8,64}\Z")
+GROK_ROSTER_MAX_BYTES = 256 * 1024
+GROK_SUMMARY_MAX_BYTES = 1024 * 1024
+GROK_CWD_MARKER_MAX_BYTES = 4096
+GROK_JSONL_TAIL_BYTES = 65536
+GROK_JSONL_MAX_LINE_BYTES = 512 * 1024
+GROK_MAX_GROUP_DIRS = 512
+GROK_MAX_GROUP_ENTRIES = 512
+# Marker files are only needed for the slug+hash (long path) layout. They get
+# their own allowance, sized so every group the scan is willing to visit can
+# still be read — a marker flood must not be able to hide a real long-path
+# session. Marker bytes are a separate bucket, so they never starve the session
+# summary/events reads that share the main cycle budget.
+GROK_MARKER_MAX_TOTAL_BYTES = GROK_MAX_GROUP_DIRS * GROK_CWD_MARKER_MAX_BYTES
+# Bounds for the marker fallback of grok_sessions_for_cwd: how many claiming
+# groups may be examined, how many sessions are taken from each (newest first),
+# and how many sessions one lookup may return. Markers are attacker-controllable
+# text, so a pile of groups all claiming the same cwd must not be able to spend
+# the cycle budget (or take over the card) by volume; groups are ranked by the
+# newest session they hold, and a group that yields no session does not consume
+# the collection budget, so the freshest real session still wins.
+GROK_MAX_MATCHED_GROUPS = 64
+GROK_MAX_MATCHED_SESSIONS = 32
+GROK_MAX_CWD_SESSIONS = 64
+GROK_CYCLE_MAX_BYTES = 2 * 1024 * 1024
+# A marker-bearing tree of GROK_MAX_GROUP_DIRS groups costs ~3 ops per group for
+# the trust walks plus one listing, so 512 groups need ~1.6k ops; the ceiling is
+# set well above that so several cards can resolve in one tick without any of
+# them silently losing their session.
+GROK_CYCLE_MAX_OPS = 16384
+GROK_CACHE_MAX_ENTRIES = 128
+GROK_WAITING_TOOLS = ("ask_user_question",)
+GROK_WORKING_PHASES = (
+    "waiting_for_model", "streaming_reasoning", "streaming_text", "tool_execution",
+)
+GROK_WAITING_PHASES = ("permission_prompt",)
+
+
+def grok_home() -> str:
+    """Grok's data dir; GROK_HOME overrides, default ~/.grok."""
+    return os.path.expanduser(os.environ.get("GROK_HOME", "~/.grok"))
+
+
+def is_grok_helper_process(cmd: str, argv: Optional[List[str]] = None) -> bool:
+    """True for `grok` invocations that are not an interactive TUI session.
+
+    Two classes: CLI verbs, identified by an exact argv[1] match, and
+    headless/info-only runs, identified by an exact flag token anywhere in the
+    scanned argv. Exact token matching only — never substring or prefix
+    matching, so `grok "fix the agent loop"` stays a session.
+    """
+    tokens = list(argv) if argv is not None else cmd.split()
+    if len(tokens) < 2 or os.path.basename(tokens[0]) != "grok":
+        return False
+    rest = tokens[1:1 + GROK_ARG_SCAN_LIMIT]
+    if rest[0] in GROK_HELPER_SUBCOMMANDS:
+        return True
+    return any(tok in GROK_NON_INTERACTIVE_FLAGS for tok in rest)
+
+
+def grok_argv_has_cwd_override(argv: Optional[List[str]]) -> bool:
+    """True when the invocation passes `--cwd`, so /proc cwd != session cwd."""
+    for tok in (argv or [])[:GROK_ARG_SCAN_LIMIT]:
+        if tok == "--cwd" or tok.startswith("--cwd="):
+            return True
+    return False
+
+
+class _GrokBudget:
+    """Per-fetch-cycle read budget and memo for Grok session files.
+
+    The bar collector re-runs agent_ctl.py every few seconds against whatever
+    exists under $GROK_HOME, so a single tick must never become unbounded work:
+    these counters cap the total bytes read and the number of file/dir
+    operations, and parsed JSON is memoized by (path, mtime, size) so a large
+    session tree costs one read per change rather than one per card. Counters
+    reset at the start of every fetch_all_agents() call.
+    """
+
+    def __init__(self) -> None:
+        self.reset()
+
+    def reset(self) -> None:
+        self.bytes_read = 0
+        self.ops = 0
+        # Parsed-JSON memo keyed by (path, inode, mtime_ns, size, cap), plus
+        # path-level memos so resolving several cards against one session tree
+        # inside a tick does not re-walk and re-stat every group directory: the
+        # trust cache holds the verdict per absolute path, the group list and the
+        # group -> `.cwd` mapping are built once. All stay bounded because every
+        # cache miss pays the op budget.
+        self.cache: Dict[Tuple[str, int, int, int, int, int], Any] = {}
+        self.trusted: Dict[str, bool] = {}
+        self.group_dirs: Optional[List[str]] = None
+        self.group_cwd: Dict[str, Optional[str]] = {}
+        self.marker_bytes = 0
+
+    def exhausted(self) -> bool:
+        return self.bytes_read > GROK_CYCLE_MAX_BYTES or self.ops > GROK_CYCLE_MAX_OPS
+
+    def spend(self, nbytes: int, ops: int = 1) -> bool:
+        self.bytes_read += max(0, int(nbytes))
+        self.ops += max(0, int(ops))
+        return not self.exhausted()
+
+    def get(self, key: Tuple[str, int, int, int, int, int]) -> Any:
+        # Touch on hit so eviction is LRU rather than FIFO: with a FIFO, a working
+        # set larger than the cache re-reads files on every look-up.
+        if key not in self.cache:
+            return None
+        value = self.cache.pop(key)
+        self.cache[key] = value
+        return value
+
+    def has(self, key: Tuple[str, int, int, int, int, int]) -> bool:
+        return key in self.cache
+
+    def store(self, key: Tuple[str, int, int, int, int, int], value: Any) -> Any:
+        # Evict the oldest entry rather than refusing to store: a machine with
+        # more sessions than the cache holds would otherwise re-read and re-parse
+        # the same files on every lookup, which is exactly what exhausts the byte
+        # budget on the machines this memo exists to protect.
+        while len(self.cache) >= GROK_CACHE_MAX_ENTRIES:
+            try:
+                self.cache.pop(next(iter(self.cache)))
+            except (StopIteration, KeyError):
+                break
+        self.cache[key] = value
+        return value
+
+
+_GROK_BUDGET = _GrokBudget()
+
+
+def grok_trusted_path(path: str) -> bool:
+    """True when `path` sits inside GROK_HOME with no symlinked or foreign component.
+
+    The plugin only ever *reads* Grok session data, so a path that is a symlink,
+    owned by another user or group/world-writable is never trusted: enrichment
+    degrades to "no card / no detail" instead of following a redirect. (Same
+    standard the Claude status-dir hardening applies to its write path.)
+    Verdicts are memoized for the duration of one fetch cycle — the op budget
+    bounds how many distinct paths can be walked, so the memo cannot grow past
+    that.
+    """
+    if _GROK_BUDGET.exhausted():
+        return False
+    try:
+        target = os.path.abspath(path)
+    except (OSError, ValueError):
+        return False
+    cached = _GROK_BUDGET.trusted.get(target)
+    if cached is not None:
+        return cached
+    verdict = _grok_trusted_path_uncached(target)
+    _GROK_BUDGET.trusted[target] = verdict
+    return verdict
+
+
+def _grok_trusted_path_uncached(target: str) -> bool:
+    """Walk every component of an absolute path up to (and including) GROK_HOME."""
+    home = os.path.abspath(grok_home())
+    if target != home and not target.startswith(home + os.sep):
+        return False
+    uid = os.getuid()
+    current = target
+    try:
+        while True:
+            st = os.lstat(current)
+            if stat.S_ISLNK(st.st_mode) or st.st_uid != uid or (st.st_mode & 0o022):
+                return False
+            if not _GROK_BUDGET.spend(0, 1):
+                return False
+            if current == home:
+                return True
+            parent = os.path.dirname(current)
+            if parent == current:
+                return False
+            current = parent
+    except (OSError, ValueError):
+        return False
+
+
+def _grok_fd_within_home(fd: int) -> bool:
+    """Containment check on the opened fd's real target, not on a pre-open path."""
+    try:
+        resolved = os.path.realpath(f"/proc/self/fd/{fd}")
+    except (OSError, ValueError):
+        return False
+    home = os.path.realpath(grok_home())
+    return resolved == home or resolved.startswith(home + os.sep)
+
+
+# O_NONBLOCK is not decoration: the file type is only known *after* the open, so
+# without it opening a FIFO (or device node) planted under $GROK_HOME blocks
+# until a writer appears — turning a hostile file into a wedged collector tick
+# instead of a "no detail" card. It is a no-op for regular files.
+_GROK_OPEN_FLAGS = os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK
+
+
+def _grok_open_verified(path: str, max_size: Optional[int] = None, marker: bool = False, whole: bool = False) -> Optional[int]:
+    """Open a trusted Grok file and return a verified fd, or None.
+
+    One place owns the security-critical steps: the trust walk on the path, the
+    O_NOFOLLOW|O_NONBLOCK open, and fd-level verification (regular file, current
+    owner, single link, optional size cap, containment in $GROK_HOME). With
+    `whole=True` the file must also fit in the budget it is charged to — a
+    truncated prefix must never be mistaken for the file itself. The caller owns
+    closing the fd.
+    """
+    if _GROK_BUDGET.exhausted() or not grok_trusted_path(path):
+        return None
+    try:
+        fd = os.open(path, _GROK_OPEN_FLAGS)
+    except (OSError, ValueError):
+        return None
+    try:
+        st = os.fstat(fd)
+        if not stat.S_ISREG(st.st_mode) or st.st_uid != os.getuid() or st.st_nlink > 1:
+            raise OSError("not a regular, owned, single-link file")
+        if max_size is not None and st.st_size > max_size:
+            raise OSError("file larger than the allowed size")
+        if whole:
+            allowance = (GROK_MARKER_MAX_TOTAL_BYTES - _GROK_BUDGET.marker_bytes) if marker else _grok_allowance()
+            if allowance <= 0 or st.st_size > allowance:
+                raise OSError("remaining budget cannot cover the whole file")
+        if not _grok_fd_within_home(fd):
+            raise OSError("not contained in GROK_HOME")
+    except OSError:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        return None
+    return fd
+
+
+def _grok_allowance() -> int:
+    """Bytes still available in this cycle's read budget (<= 0 when spent)."""
+    return GROK_CYCLE_MAX_BYTES - _GROK_BUDGET.bytes_read
+
+
+def _grok_read_at(fd: int, offset: int, length: int, marker: bool = False) -> Optional[bytes]:
+    """Read `length` bytes at `offset` from a verified fd.
+
+    Reads are charged to the cycle budget and can never take it over the ceiling.
+    `marker=True` charges the separate marker allowance instead, so a tree full of
+    large `.cwd` markers cannot starve real session reads.
+    """
+    if marker:
+        allowance = GROK_MARKER_MAX_TOTAL_BYTES - _GROK_BUDGET.marker_bytes
+    else:
+        allowance = _grok_allowance()
+    if allowance <= 0 or length <= 0:
+        return None
+    try:
+        os.lseek(fd, offset, os.SEEK_SET)
+        data = os.read(fd, min(length, allowance))
+    except (OSError, ValueError):
+        return None
+    if not data:
+        return b""
+    if marker:
+        _GROK_BUDGET.marker_bytes += len(data)
+    elif not _GROK_BUDGET.spend(len(data)):
+        return None
+    return data
+
+
+def grok_read_bytes(path: str, max_bytes: int) -> Optional[bytes]:
+    """Read a whole trusted Grok file, refusing anything larger than `max_bytes`.
+
+    The opened fd is what gets verified (see _grok_open_verified), so a symlink
+    swapped in after the path check cannot redirect the read and a FIFO cannot
+    block it. Returns None — never raises — whenever anything is off.
+    """
+    fd = _grok_open_verified(path, max_size=max_bytes, whole=True)
+    if fd is None:
+        return None
+    try:
+        return _grok_read_at(fd, 0, max_bytes)
+    finally:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+
+
+def grok_read_marker_bytes(path: str) -> Optional[bytes]:
+    """Read a whole `.cwd` marker against the marker allowance.
+
+    Whole-file only: a marker read that the remaining allowance would truncate is
+    refused, because a truncated marker is a wrong path and would be accepted as a
+    breadcrumb or a group match.
+    """
+    if _GROK_BUDGET.exhausted() or _GROK_BUDGET.marker_bytes >= GROK_MARKER_MAX_TOTAL_BYTES:
+        return None
+    fd = _grok_open_verified(path, max_size=GROK_CWD_MARKER_MAX_BYTES, marker=True, whole=True)
+    if fd is None:
+        return None
+    try:
+        return _grok_read_at(fd, 0, GROK_CWD_MARKER_MAX_BYTES, marker=True)
+    finally:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+
+
+def grok_read_last_lines(path: str, max_lines: int = 200, chunk_bytes: int = GROK_JSONL_TAIL_BYTES, max_total: int = GROK_JSONL_MAX_LINE_BYTES) -> Optional[bytes]:
+    """Read the tail of a trusted JSONL file backwards until `max_lines` lines.
+
+    Chunks are read from the end and each is charged once — no window is re-read —
+    so the byte cost is proportional to what is actually needed. A single very
+    long line widens the read one chunk at a time up to `max_total`; a line larger
+    than that absolute ceiling is dropped (documented limit) rather than parsed
+    from a fragment. The returned bytes may start mid-line; callers drop that
+    first fragment.
+    """
+    fd = _grok_open_verified(path)
+    if fd is None:
+        return None
+    try:
+        try:
+            size = os.fstat(fd).st_size
+        except OSError:
+            return b""
+        parts: List[bytes] = []
+        total = 0
+        newlines = 0
+        pos = size
+        while pos > 0 and total < max_total and newlines <= max_lines:
+            allowance = _grok_allowance()
+            if allowance <= 0:
+                break
+            # Clamp the WINDOW before computing the offset: this reader walks
+            # backwards, so a length-clamped read would hand back the oldest bytes
+            # of the window instead of the newest, silently losing the events that
+            # decide the card's status.
+            take = min(chunk_bytes, pos, max_total - total, allowance)
+            if take <= 0:
+                break
+            data = _grok_read_at(fd, pos - take, take)
+            if data is None or not data:
+                break
+            parts.append(data)
+            total += len(data)
+            pos -= len(data)
+            newlines += data.count(b"\n")
+        if not parts:
+            return b""
+        return b"".join(reversed(parts))
+    finally:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+
+
+
+def grok_read_json(path: str, max_bytes: int) -> Any:
+    """Parsed JSON from a trusted Grok file, or None. Never raises."""
+    raw = grok_read_bytes(path, max_bytes)
+    if raw is None:
+        return None
+    try:
+        return json.loads(raw.decode("utf-8", errors="replace"))
+    except Exception:
+        return None
+
+
+def grok_read_json_cached(path: str, max_bytes: int) -> Any:
+    """grok_read_json memoized per (path, inode, mtime, size, cap) for one cycle."""
+    if _GROK_BUDGET.exhausted():
+        return None
+    try:
+        st = os.stat(path)
+        key = (path, int(st.st_ino), int(st.st_mtime_ns), int(st.st_ctime_ns), int(st.st_size), int(max_bytes))
+    except (OSError, ValueError):
+        return None
+    if _GROK_BUDGET.has(key):
+        return _GROK_BUDGET.get(key)
+    return _GROK_BUDGET.store(key, grok_read_json(path, max_bytes))
+
+
+def grok_is_regular_file(path: str) -> bool:
+    """True for a trusted regular, single-link file — never follows a symlink.
+
+    Used wherever the code decides "this is a session / this stream exists":
+    os.path.isfile()/exists() follow symlinks and would accept a planted link
+    even though the guarded reader then refuses its contents.
+    """
+    if _GROK_BUDGET.exhausted() or not grok_trusted_path(path):
+        return False
+    try:
+        st = os.lstat(path)
+    except (OSError, ValueError):
+        return False
+    return stat.S_ISREG(st.st_mode) and st.st_nlink == 1
+
+
+def grok_listdir(path: str, max_entries: int = GROK_MAX_GROUP_ENTRIES) -> List[str]:
+    """Bounded, trusted, sorted directory listing; [] when untrusted or over budget."""
+    if _GROK_BUDGET.exhausted() or not grok_trusted_path(path):
+        return []
+    try:
+        st = os.stat(path)
+    except (OSError, ValueError):
+        return []
+    if not stat.S_ISDIR(st.st_mode) or st.st_uid != os.getuid() or not _GROK_BUDGET.spend(0, 1):
+        return []
+    names: List[str] = []
+    try:
+        with os.scandir(path) as it:
+            for entry in it:
+                names.append(entry.name)
+                if len(names) >= max_entries:
+                    break
+    except (OSError, ValueError):
+        return []
+    return sorted(names)
+
+
+def grok_session_is_subagent(session_dir: str) -> bool:
+    """Skip forked subagent sessions so the parent card is not counted twice."""
+    summary = grok_read_json_cached(os.path.join(session_dir, "summary.json"), GROK_SUMMARY_MAX_BYTES)
+    if not isinstance(summary, dict):
+        return False
+    # session_kind is the reliable flag (agent_name is the role, e.g. general-purpose).
+    for key in ("session_kind", "agent_name", "session_relationship"):
+        val = str(summary.get(key) or "")
+        if val.startswith("subagent"):
+            return True
+    return False
+
+
+def grok_sessions_root() -> str:
+    """Grok's sessions root ($GROK_HOME/sessions)."""
+    return os.path.join(grok_home(), "sessions")
+
+
+def grok_group_dirs() -> List[str]:
+    """Trusted group directories under the sessions root, bounded and sorted.
+
+    Built once per fetch cycle: resolving several cards against one session tree
+    would otherwise re-list and re-stat every group directory each time and burn
+    the op budget.
+    """
+    if _GROK_BUDGET.group_dirs is not None:
+        return _GROK_BUDGET.group_dirs
+    root = grok_sessions_root()
+    groups: List[str] = []
+    for name in grok_listdir(root, GROK_MAX_GROUP_DIRS):
+        if len(groups) >= GROK_MAX_GROUP_DIRS:
+            break
+        path = os.path.join(root, name)
+        if grok_trusted_path(path):
+            groups.append(path)
+    _GROK_BUDGET.group_dirs = groups
+    return groups
+
+
+def grok_group_dir_for_name(encoded: str) -> Optional[str]:
+    """Map an encoded cwd name to a real group directory, refusing dot components.
+
+    quote(cwd, safe="") deliberately leaves '.' unescaped, so a roster cwd of
+    '.' or '..' would otherwise resolve to the sessions root or to GROK_HOME
+    itself. The candidate must be a direct child of the sessions root.
+    """
+    if not encoded or encoded in (".", "..") or "/" in encoded or os.sep in encoded:
+        return None
+    root = os.path.abspath(grok_sessions_root())
+    candidate = os.path.abspath(os.path.join(root, encoded))
+    if os.path.dirname(candidate) != root:
+        return None
+    return candidate
+
+
+def grok_session_dir_for_id(cwd: str, session_id: str) -> Optional[str]:
+    """Resolve a live session's directory from its (uuid) session id.
+
+    The id — not the group name — is the reliable key. The encoded-cwd fast path
+    short-circuits when it works; the bounded group scan then finds the session
+    whatever Grok called the group, including the slug+hash group it uses when
+    the encoded cwd exceeds 255 bytes (documented layout), and regardless of
+    whether our encoder matches Grok's byte for byte.
+    """
+    if not GROK_SESSION_ID_RE.match(session_id or ""):
+        return None
+    root = grok_sessions_root()
+    if cwd:
+        encoded_names: List[str] = []
+        try:
+            for value in (cwd, os.path.realpath(cwd)):
+                encoded = quote(value, safe="")
+                if encoded not in encoded_names:
+                    encoded_names.append(encoded)
+        except (OSError, ValueError):
+            encoded_names = []
+        for encoded in encoded_names:
+            group = grok_group_dir_for_name(encoded)
+            if not group:
+                continue
+            candidate = os.path.join(group, session_id)
+            if grok_is_regular_file(os.path.join(candidate, "summary.json")):
+                return candidate
+    for group in grok_group_dirs():
+        candidate = os.path.join(group, session_id)
+        if grok_is_regular_file(os.path.join(candidate, "summary.json")):
+            return candidate
+    return None
+
+
+def grok_active_session_for_pid(pid: int) -> Optional[str]:
+    """Map a live grok PID to its session directory via active_sessions.json.
+
+    The roster is read-only input: a row only counts when its pid is this live
+    process, its session_id passes the uuid check, and the resolved directory is
+    inside the trusted tree. Anything else is dropped rather than guessed at.
+    """
+    if pid <= 1 or not os.path.exists(f"/proc/{pid}"):
+        return None
+    rows = grok_read_json_cached(os.path.join(grok_home(), "active_sessions.json"), GROK_ROSTER_MAX_BYTES)
+    if not isinstance(rows, list):
+        return None
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        try:
+            row_pid = int(row.get("pid"))
+        except (TypeError, ValueError, OverflowError):
+            continue
+        if row_pid != pid:
+            continue
+        session_id = str(row.get("session_id") or "")
+        cwd = str(row.get("cwd") or "")
+        if not GROK_SESSION_ID_RE.match(session_id):
+            continue
+        session_dir = grok_session_dir_for_id(cwd, session_id)
+        if session_dir and not grok_session_is_subagent(session_dir):
+            return session_dir
+    return None
+
+
+def grok_summary_mtime(session_dir: str) -> float:
+    """summary.json mtime of a session dir (0.0 when it is not a plain file).
+
+    lstat, not getmtime: a symlinked summary.json that every reader refuses must
+    not contribute its target's mtime to the newest-first ordering.
+    """
+    try:
+        st = os.lstat(os.path.join(session_dir, "summary.json"))
+    except (OSError, ValueError):
+        return 0.0
+    if not stat.S_ISREG(st.st_mode) or st.st_nlink > 1:
+        return 0.0
+    return float(st.st_mtime)
+
+
+def grok_group_cwd_marker(group_dir: str) -> Optional[str]:
+    """The absolute cwd recorded in a group's `.cwd` marker file, or None.
+
+    Grok writes this marker only for groups whose name is a slug+hash, i.e. when
+    the URL-encoded path exceeded 255 bytes. The file's contents are untrusted
+    text — a local file can hold anything — so they are flattened, redacted and
+    capped before use, and only a value that actually looks like an absolute path
+    is accepted. The marker is never used to build a path, and the mapping is
+    memoized for the cycle, which is also what keeps a 512-group scan inside the
+    op budget.
+    """
+    if group_dir in _GROK_BUDGET.group_cwd:
+        return _GROK_BUDGET.group_cwd[group_dir]
+    recorded = None
+    marker = grok_read_marker_bytes(os.path.join(group_dir, ".cwd"))
+    if marker is not None:
+        text = grok_clean_detail(marker.decode("utf-8", errors="replace"), GROK_CWD_MARKER_MAX_BYTES)
+        # A marker is only ever a path: absolute, with no space or control byte
+        # left in it after cleaning. Anything else is dropped rather than rendered
+        # as "the repo path".
+        if text.startswith("/") and " " not in text:
+            recorded = text
+    _GROK_BUDGET.group_cwd[group_dir] = recorded
+    return recorded
+
+
+def grok_group_cwd(group_dir: str) -> str:
+    """The working directory a session group belongs to.
+
+    Prefers the `.cwd` marker and falls back to the decoded group name, which is
+    how Grok names groups for ordinary (short) paths.
+    """
+    recorded = grok_group_cwd_marker(group_dir)
+    if recorded:
+        return recorded
+    try:
+        return unquote(os.path.basename(group_dir))
+    except Exception:
+        return ""
+
+
+def grok_sessions_for_cwd(cwd: str) -> List[str]:
+    """Session directories for a cwd, best-first (encoded group, then markers).
+
+    Two group-naming schemes are covered: the URL-encoded cwd (literal and
+    realpath forms) and slug+hash groups whose `.cwd` marker names this cwd. The
+    encoded name is deterministic, so it is tried first and, when it yields a
+    session, the marker scan is skipped entirely: marker contents are
+    attacker-controllable text, and a group that merely claims this cwd must never
+    outrank the real one or spend the budget its summary/events reads need. For the
+    same reason the number of marker-matched groups enumerated per cwd is capped.
+    """
+    if not cwd:
+        return []
+    wanted = [cwd]
+    try:
+        real = os.path.realpath(cwd)
+    except (OSError, ValueError):
+        real = ""
+    if real and real not in wanted:
+        wanted.append(real)
+
+    fast_folders: List[str] = []
+    for value in wanted:
+        try:
+            folder = grok_group_dir_for_name(quote(value, safe=""))
+        except (OSError, ValueError):
+            folder = None
+        if folder and folder not in fast_folders:
+            fast_folders.append(folder)
+
+    found: List[str] = []
+    for folder in fast_folders:
+        for name in grok_listdir(folder):
+            path = os.path.join(folder, name)
+            if grok_is_regular_file(os.path.join(path, "summary.json")) and not grok_session_is_subagent(path):
+                found.append(path)
+    if found:
+        found.sort(key=grok_summary_mtime, reverse=True)
+        return found
+
+    # Fallback: groups whose `.cwd` marker claims this cwd (the slug+hash layout
+    # Grok uses for very long paths). Marker content is local file text, so a group
+    # that merely claims the directory must not crowd out the real session. Two
+    # rules keep that true: groups are ranked by the newest session they hold, and
+    # only sessions that actually pass the filters count — a group that yields
+    # nothing (empty, or subagent-only) never consumes the collection budget, so a
+    # pile of claimants cannot bury the real session behind the cap.
+    candidates: List[Tuple[float, str]] = []
+    for group in grok_group_dirs():
+        if group in fast_folders or grok_group_cwd(group) not in wanted:
+            continue
+        newest = max(
+            (grok_summary_mtime(os.path.join(group, name)) for name in grok_listdir(group)),
+            default=0.0,
+        )
+        candidates.append((newest, group))
+    candidates.sort(reverse=True)
+
+    found: List[str] = []
+    for _, group in candidates:
+        if len(found) >= GROK_MAX_CWD_SESSIONS:
+            break
+        # Newest-first *before* truncating: taking the first N in name order would
+        # keep whichever sessions happen to sort first, not the freshest ones.
+        ranked = [n for n in grok_listdir(group) if grok_is_regular_file(os.path.join(group, n, "summary.json"))]
+        ranked.sort(key=lambda n: grok_summary_mtime(os.path.join(group, n)), reverse=True)
+        for name in ranked[:GROK_MAX_MATCHED_SESSIONS]:
+            path = os.path.join(group, name)
+            if grok_session_is_subagent(path):
+                continue
+            found.append(path)
+            if len(found) >= GROK_MAX_CWD_SESSIONS:
+                break
+    found.sort(key=grok_summary_mtime, reverse=True)
+    return found
+
+
+def _iter_jsonl_tail(path: str, max_lines: int = 200) -> List[Dict[str, Any]]:
+    """Parsed events from the tail of a trusted Grok JSONL file (newest kept).
+
+    The tail is read backwards in chunks until `max_lines` lines are covered (or
+    the 512 KiB ceiling is reached), so a decisive event larger than a single
+    chunk is still parsed rather than truncated into a fragment. Lines are parsed
+    whole and only the newest `max_lines` non-empty ones are returned.
+    """
+    raw = grok_read_last_lines(path, max_lines=max_lines)
+    if not raw:
+        return []
+    lines = [line.strip() for line in raw.decode("utf-8", errors="replace").split("\n")]
+    entries: List[Dict[str, Any]] = []
+    for line in [line for line in lines if line][-max_lines:]:
+        try:
+            obj = json.loads(line)
+        except Exception:
+            continue
+        if isinstance(obj, dict):
+            entries.append(obj)
+    return entries
+
+
+def grok_clean_detail(text: str, max_len: int = 200) -> str:
+    """Redact, flatten and cap an event-supplied detail line for the UI.
+
+    events.jsonl is agent-written content like every other detail source, so it
+    takes the same secret-redaction pass every other detail does — a tool name
+    is normally harmless, but nothing here may leak a token into an always-on
+    bar just because it arrived in the wrong field. C0/C1 control bytes are
+    dropped as well: clean_ansi() only understands CSI/Fe sequences, so an OSC or
+    a bare BEL would otherwise survive into a Text element.
+    """
+    cleaned = clean_ansi(str(text or ""))
+    cleaned = re.sub(r"[\x00-\x1f\x7f-\x9f]", " ", cleaned)
+    return " ".join(redact_secrets(cleaned).split())[:max_len]
+
+
+def grok_phase_detail(phase: str) -> str:
+    """Human-readable detail text for a Grok phase name."""
+    if phase == "waiting_for_model":
+        return "Thinking…"
+    if phase == "streaming_reasoning":
+        return "Reasoning…"
+    if phase == "tool_execution":
+        return "Running tool"
+    return "Generating response…"
+
+
+def extract_grok_task_from_session(
+    session_dir: str,
+) -> Tuple[Optional[str], Optional[str], Optional[str], Optional[str], bool]:
+    """Read a Grok session directory.
+
+    Returns (latest_user_prompt, detail_text, model_name, status_override, has_question).
+    Status comes from a bounded tail of events.jsonl; the title/model from summary.json
+    plus the last real user line in chat_history.jsonl.
+    """
+    if not session_dir or not grok_trusted_path(session_dir):
+        return None, None, None, None, False
+
+    model_name = None
+    latest_user_prompt = None
+    last_turn_summary = None
+    summary_path = os.path.join(session_dir, "summary.json")
+    summary = grok_read_json_cached(summary_path, GROK_SUMMARY_MAX_BYTES)
+    if isinstance(summary, dict):
+        # The model id is file-supplied text like every other field, so it takes
+        # the same flatten/redact/cap pass before it reaches the model chip.
+        model_name = grok_clean_detail(clean_model_name(summary.get("current_model_id") or ""), 120)
+        title = summary.get("generated_title") or summary.get("session_summary") or ""
+        if isinstance(title, str) and title.strip():
+            latest_user_prompt = grok_clean_detail(clean_user_prompt(title), 300)
+        turn = summary.get("last_turn_summary")
+        if isinstance(turn, str) and turn.strip():
+            last_turn_summary = grok_clean_detail(extract_first_line(turn), 200)
+
+    history_path = os.path.join(session_dir, "chat_history.jsonl")
+    if grok_is_regular_file(history_path):
+        for entry in reversed(_iter_jsonl_tail(history_path)):
+            if entry.get("type") != "user":
+                continue
+            if entry.get("synthetic_reason"):
+                continue
+            content = entry.get("content")
+            raw = content if isinstance(content, str) else ""
+            cleaned = grok_clean_detail(clean_user_prompt(raw), MAX_PROMPT_CHARS)
+            if cleaned and not is_system_wrapper(cleaned):
+                latest_user_prompt = cleaned
+                break
+
+    # Event state is folded in log order so the LAST event wins: a tool that
+    # started after a permission prompt means "working" (not "waiting"), and a
+    # stale permission_prompt phase cannot mask the tool that is running now.
+    pending_tool: Optional[str] = None
+    pending_permission: Optional[str] = None
+    phase: Optional[str] = None
+    turn_open = False
+    turn_finished = False
+    events_path = os.path.join(session_dir, "events.jsonl")
+    if grok_is_regular_file(events_path):
+        for entry in _iter_jsonl_tail(events_path):
+            et = entry.get("type")
+            if et == "turn_started":
+                turn_open = True
+                turn_finished = False
+                pending_tool = None
+                pending_permission = None
+                phase = "waiting_for_model"
+            elif et == "turn_ended":
+                turn_open = False
+                turn_finished = True
+                pending_tool = None
+                pending_permission = None
+                phase = None
+            elif et == "phase_changed":
+                value = entry.get("phase")
+                if isinstance(value, str):
+                    phase = value
+            elif et == "tool_started":
+                pending_tool = str(entry.get("tool_name") or "tool")
+                pending_permission = None
+                phase = "tool_execution"
+            elif et == "tool_completed":
+                pending_tool = None
+            elif et == "permission_requested":
+                pending_permission = str(entry.get("tool_name") or "tool")
+                pending_tool = None
+            elif et == "permission_resolved":
+                pending_permission = None
+                # Auto-allowed asks leave phase=permission_prompt behind; the
+                # turn is no longer waiting on the user.
+                if phase in GROK_WAITING_PHASES:
+                    phase = "tool_execution" if pending_tool else "waiting_for_model"
+
+    status_override = None
+    detail = None
+    has_question = False
+    if pending_permission:
+        status_override = "waiting"
+        detail = grok_clean_detail(f"Permission: {pending_permission}")
+        has_question = True
+    elif pending_tool in GROK_WAITING_TOOLS:
+        status_override = "waiting"
+        detail = "Waiting for input"
+        has_question = True
+    elif pending_tool:
+        status_override = "working"
+        detail = grok_clean_detail(f"Running: {pending_tool}")
+    elif phase in GROK_WORKING_PHASES:
+        status_override = "working"
+        detail = grok_phase_detail(phase)
+    elif phase in GROK_WAITING_PHASES:
+        status_override = "waiting"
+        detail = "Waiting for permission"
+        has_question = True
+    elif turn_open:
+        status_override = "working"
+        detail = "Thinking…"
+    elif turn_finished:
+        status_override = "completed"
+        detail = last_turn_summary or "Task completed"
+    else:
+        status_override = "idle"
+        detail = "Ready for prompt"
+
+    return latest_user_prompt, detail, model_name or "", status_override, has_question
+
+
 def is_valid_agent_process(pid: int) -> bool:
     """Validate that a PID actually corresponds to an active AI agent process before signaling."""
     if pid <= 1:
@@ -273,7 +1146,10 @@ def is_valid_agent_process(pid: int) -> bool:
     cmd = info["cmd"]
     tokens = cmd.split()
     first = os.path.basename(tokens[0]) if tokens else ""
-    if first in ("omp", "pi", "claude", "codex", "opencode", "cline", "cursor", "agy") and not is_claude_helper_process(cmd, info.get("argv")):
+    argv = info.get("argv")
+    if first == "grok" and not is_grok_helper_process(cmd, argv):
+        return True
+    if first in ("omp", "pi", "claude", "codex", "opencode", "cline", "cursor", "agy") and not is_claude_helper_process(cmd, argv):
         return True
     if first in ("python", "python3") and is_hermes_cli_process(cmd):
         return True
@@ -428,8 +1304,29 @@ def read_claude_hook_status(pid: int) -> Optional[Dict[str, str]]:
     }
 
 
-def find_session_for_process(agent_type: str, pid: int, cwd: str, claimed_sessions: Set[str]) -> Optional[str]:
+def find_session_for_process(agent_type: str, pid: int, cwd: str, claimed_sessions: Set[str], argv: Optional[List[str]] = None) -> Optional[str]:
     """Find active or recent session file strictly belonging to this specific process."""
+    if agent_type == "grok":
+        # 1. The live roster is authoritative: it is keyed by the session's own
+        #    pid, so concurrent sessions in one cwd stay distinct, and its cwd is
+        #    Grok's view of the session directory rather than /proc's.
+        active = grok_active_session_for_pid(pid)
+        if active:
+            return active if active not in claimed_sessions else None
+        # 2. Fallback for a session the roster has not caught up with. Skip it
+        #    entirely when the invocation passed `--cwd`: the process cwd is then
+        #    not the session cwd, and a wrong card is worse than no card.
+        if grok_argv_has_cwd_override(argv):
+            return None
+        p_start = get_process_start_time(pid)
+        for session_dir in grok_sessions_for_cwd(cwd):
+            if session_dir in claimed_sessions or grok_session_is_subagent(session_dir):
+                continue
+            mtime = grok_summary_mtime(session_dir)
+            if p_start > 0 and mtime >= (p_start - 5.0):
+                return session_dir
+        return None
+
     if agent_type == "omp":
         # 1. Check PTS terminal session mapping in ~/.omp/agent/terminal-sessions/pts-<N>
         try:
@@ -503,6 +1400,14 @@ def match_hypr_client_for_terminal(ancestor_pids: List[int], cwd: str, agent_typ
 def find_latest_session_for_cwd(agent_type: str, cwd: str, claimed_sessions: Optional[Set[str]] = None) -> Optional[str]:
     """Find the most recent session file matching a working directory that is not already claimed."""
     claimed = claimed_sessions or set()
+    if agent_type == "grok":
+        try:
+            for session_dir in grok_sessions_for_cwd(cwd):
+                if session_dir not in claimed and not grok_session_is_subagent(session_dir):
+                    return session_dir
+        except Exception:
+            pass
+        return None
     if agent_type == "omp" and os.path.exists(OMP_SESSIONS_DIR):
         try:
             folder_part = os.path.basename(cwd.rstrip("/")) if cwd else ""
@@ -536,7 +1441,7 @@ def extract_first_line(text: str, max_len: int = 140) -> str:
         line = re.sub(r"\*\*([^*]+)\*\*", r"\1", line)
         line = re.sub(r"\*([^*]+)\*", r"\1", line)
         line = re.sub(r"`([^`]+)`", r"\1", line)
-        line = " ".join(line.split())
+        line = " ".join(re.sub(r"[\x00-\x1f\x7f-\x9f]", " ", clean_ansi(line)).split())
         if not line:
             continue
         line = redact_secrets(line)
@@ -544,6 +1449,9 @@ def extract_first_line(text: str, max_len: int = 140) -> str:
             return line[:max_len - 1].rstrip() + "…"
         return line
     return ""
+
+
+MAX_PROMPT_CHARS = 400  # display cap for prompt/title text (card title, bar headline)
 
 
 def clean_user_prompt(text: str) -> str:
@@ -554,8 +1462,15 @@ def clean_user_prompt(text: str) -> str:
     cleaned = re.sub(r"<system-directive>.*?</system-directive>", "", cleaned, flags=re.DOTALL).strip()
     cleaned = re.sub(r"<[^>]+>", "", cleaned).strip()
     cleaned = re.sub(r"^#+\s*", "", cleaned).strip()
+    # Untrusted text (session transcripts, terminal titles): drop escape sequences
+    # and control bytes before redaction — an embedded control byte both reaches
+    # the UI and splits a credential so the token regex no longer matches it.
+    cleaned = clean_ansi(cleaned)
+    cleaned = re.sub(r"[\x00-\x1f\x7f-\x9f]", " ", cleaned)
     cleaned = redact_secrets(cleaned)
-    return " ".join(cleaned.split())
+    # Display text only, but it ends up in card titles and the bar headline, so cap
+    # it: an unbounded prompt would otherwise inflate the whole status payload.
+    return " ".join(cleaned.split())[:MAX_PROMPT_CHARS]
 
 
 def is_system_wrapper(text: str) -> bool:
@@ -1006,6 +1921,7 @@ _ORCA_AGENT_ALIASES = {
     "agy": "agy",
     "cursor": "cursor",
     "cline": "cline",
+    "grok": "grok",
 }
 
 # Bare shells / system programs that mean "no agent in this terminal".
@@ -1041,6 +1957,7 @@ _ORCA_MODEL_AGENT_HINTS = (
     ("o3", "codex"),
     ("o4", "codex"),
     ("gemini", "gemini"),
+    ("grok", "grok"),
 )
 
 # Unambiguous agent-TUI chrome strings (beyond the CLI's own name) that can
@@ -1053,11 +1970,12 @@ _ORCA_PREVIEW_CHROME_MARKERS = {
     "codex": (),
     "opencode": (),
     "agy": (),
+    "grok": (),
 }
 
 # Agent names looked up literally (as words) in the preview when the title's
 # model token yields no hint. Ordered most-specific first.
-_ORCA_PREVIEW_AGENT_NAMES = ("hermes", "opencode", "gemini", "claude", "codex", "omp", "agy", "pi")
+_ORCA_PREVIEW_AGENT_NAMES = ("hermes", "opencode", "gemini", "claude", "codex", "omp", "agy", "pi", "grok")
 
 
 def _contains_word(haystack: str, word: str) -> bool:
@@ -1287,6 +2205,8 @@ def scan_orca_agents(claimed_sessions: Set[str]) -> List[Dict[str, Any]]:
                 claimed_sessions.add(session_path)
                 if agent_type == "omp" and os.path.exists(session_path):
                     user_goal, detail_text, model_name, status_override, has_question = extract_omp_task_from_session(session_path)
+                elif agent_type == "grok":
+                    user_goal, detail_text, model_name, status_override, has_question = extract_grok_task_from_session(session_path)
                 elif agent_type == "hermes":
                     _, model_name, _, _, detail_text, status_override, has_question = extract_hermes_session_info(source_preference="cli")
             elif agent_type == "omp":
@@ -1366,7 +2286,7 @@ def scan_standalone_agents(herdr_server_pids: List[int], seen_cwds: Set[str], cl
             )
 
             # Skip anything running inside Herdr, spawned as an internal background worker, or system usage script
-            if is_in_herdr or is_broker_child or is_claude_helper_process(cmd, info.get("argv")) or "omarchy-agent-usage" in cmd or "__omp_worker" in cmd or "gateway run" in cmd or "serve --host" in cmd or "zygote" in cmd or "agent_ctl.py" in cmd:
+            if is_in_herdr or is_broker_child or is_claude_helper_process(cmd, info.get("argv")) or is_grok_helper_process(cmd, info.get("argv")) or "omarchy-agent-usage" in cmd or "__omp_worker" in cmd or "gateway run" in cmd or "serve --host" in cmd or "zygote" in cmd or "agent_ctl.py" in cmd:
                 continue
 
             # Check if this is a Hermes Desktop GUI process
@@ -1407,6 +2327,8 @@ def scan_standalone_agents(herdr_server_pids: List[int], seen_cwds: Set[str], cl
             elif first == "agy":
                 # Google Antigravity CLI - no JSONL transcripts; generic enrichment
                 agent_type = "agy"
+            elif first == "grok":
+                agent_type = "grok"
             elif first in ("claude", "codex", "opencode", "cline", "cursor"):
                 agent_type = first
             elif first in ("python", "python3") and is_hermes_cli_process(cmd):
@@ -1450,7 +2372,16 @@ def scan_standalone_agents(herdr_server_pids: List[int], seen_cwds: Set[str], cl
                 # the session itself, so it wins over transcript inference and
                 # over the process-state guess further down.
                 claude_hook_status = read_claude_hook_status(pid) if agent_type == "claude" else None
-                session_path = None if claude_hook_status else find_session_for_process(agent_type, pid, cwd, claimed_sessions)
+                session_path = None if claude_hook_status else find_session_for_process(agent_type, pid, cwd, claimed_sessions, info.get("argv"))
+                if agent_type == "grok" and session_path:
+                    # Only a real `.cwd` marker (long-path slug+hash groups) may
+                    # override the breadcrumb: falling back to the decoded group
+                    # name here would print a slug+hash as if it were a path.
+                    session_cwd = grok_group_cwd_marker(os.path.dirname(session_path))
+                    if session_cwd:
+                        cwd = session_cwd
+                        repo_name = os.path.basename(cwd.rstrip("/")) if cwd else ""
+                        clean_cwd = shorten_path(cwd)
                 user_goal = None
                 detail_text = None
                 model_name = None
@@ -1468,6 +2399,8 @@ def scan_standalone_agents(herdr_server_pids: List[int], seen_cwds: Set[str], cl
                             user_goal, detail_text, model_name, status_override, has_question = extract_omp_task_from_session(session_path)
                         else:
                             model_name = get_omp_default_model()
+                    elif agent_type == "grok":
+                        user_goal, detail_text, model_name, status_override, has_question = extract_grok_task_from_session(session_path)
                     elif agent_type == "hermes":
                         p_st = get_process_start_time(pid)
                         user_goal, model_name, _, _, detail_text, status_override, has_question = extract_hermes_session_info(source_preference="cli", min_start_time=p_st)
@@ -1516,6 +2449,9 @@ def scan_standalone_agents(herdr_server_pids: List[int], seen_cwds: Set[str], cl
 
 def fetch_all_agents() -> Dict[str, Any]:
     """Fetch all agent data, combining Herdr snapshot, session enrichment, and standalone processes."""
+    # Grok session reads are budgeted per fetch cycle, so a large or hostile
+    # $GROK_HOME cannot turn one tick into unbounded work.
+    _GROK_BUDGET.reset()
     herdr_pids = get_herdr_server_pids()
 
     agents_list = []
@@ -1604,6 +2540,8 @@ def fetch_all_agents() -> Dict[str, Any]:
 
             if agent_type == "omp" and session_path:
                 user_goal, detail_text, model_name, status_override, has_question = extract_omp_task_from_session(session_path)
+            elif agent_type == "grok" and session_path:
+                user_goal, detail_text, model_name, status_override, has_question = extract_grok_task_from_session(session_path)
             elif agent_type == "hermes":
                 hermes_p_start = None
                 for hp in glob.glob("/proc/[0-9]*"):
@@ -2009,10 +2947,116 @@ def launch_agent(agent_name: Optional[str] = None) -> Dict[str, Any]:
         return {"ok": False, "error": str(e)}
 
 
+STATUS_MAX_AGENTS = 256      # agent cards kept in one status payload
+STATUS_MAX_WORKSPACES = 128  # workspace labels kept in one status payload
+STATUS_MAX_BYTES = 262144    # hard ceiling on the serialized status payload
+
+
+_STATUS_TEXT_MAX = 400       # per-string clip applied to agent-supplied fields
+_STATUS_NUMBER_BOUND = 10 ** 12
+
+
+def _clip_text(value: Any, limit: int = _STATUS_TEXT_MAX) -> str:
+    """Coerce a display string to a whitespace-flattened, clipped form."""
+    text = value if isinstance(value, str) else ("" if value is None else str(value))
+    return " ".join(text.split())[:limit]
+
+
+def _bounded_number(value: Any) -> Any:
+    """Bound numeric payload fields so a pathological int cannot break json.dumps.
+
+    Python refuses to serialize ints past ~4300 digits; this is not reachable from
+    session files today (every file-sourced value is str()-coerced or a bounded
+    count) but the serializer is the last line of defence, so it is clamped here.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return value
+    try:
+        if isinstance(value, float):
+            return value if value == value and abs(value) != float("inf") else 0.0
+        return max(-_STATUS_NUMBER_BOUND, min(_STATUS_NUMBER_BOUND, int(value)))
+    except Exception:
+        return 0
+
+
+def _dumps(payload: Dict[str, Any]) -> str:
+    """json.dumps that never raises: unencodable values fall back to their str()."""
+    try:
+        return json.dumps(payload, indent=2)
+    except Exception:
+        try:
+            return json.dumps(payload, indent=2, default=str)
+        except Exception:
+            return ""
+
+
+def dump_status_json(data: Dict[str, Any]) -> str:
+    """Serialize the status payload inside a hard, structural size bound.
+
+    The panel reads this through a StdioCollector with no cap of its own and then
+    slices whatever arrives to 262144 characters before JSON.parse, so the reply
+    has to be valid JSON *within* that bound — truncating mid-JSON would just
+    freeze the widget on stale data. Every agent-supplied string is clipped first
+    (a single hostile session file must not be able to inflate the reply), then the
+    agent list is capped, and only if the result still exceeds the ceiling is the
+    payload reduced to numeric counts.
+    """
+    payload = dict(data)
+    agents = payload.get("agents")
+    if isinstance(agents, list):
+        clipped: List[Any] = []
+        for agent in agents[:STATUS_MAX_AGENTS]:
+            if isinstance(agent, dict):
+                clipped.append({k: (_clip_text(v) if isinstance(v, str) else _bounded_number(v)) for k, v in agent.items()})
+        payload["agents"] = clipped
+    summary = payload.get("summary")
+    if isinstance(summary, dict):
+        payload["summary"] = {
+            k: (_clip_text(v, 300) if isinstance(v, str) else _bounded_number(v))
+            for k, v in summary.items()
+        }
+    workspaces = payload.get("workspaces")
+    if isinstance(workspaces, list):
+        payload["workspaces"] = [_clip_text(w, 200) for w in workspaces[:STATUS_MAX_WORKSPACES]]
+    text = _dumps(payload)
+    if text and len(text) <= STATUS_MAX_BYTES:
+        return text
+
+    # Still oversized (or unserializable): keep the counts, drop every free-text
+    # field, and bound the numbers so this reply cannot grow with any input.
+    counts: Dict[str, Any] = {}
+    for key, value in (summary if isinstance(summary, dict) else {}).items():
+        if isinstance(value, (bool, int, float)):
+            counts[key] = _bounded_number(value)
+        elif key == "active_agents" and isinstance(value, list):
+            counts[key] = [_clip_text(item, 40) for item in value[:32]]
+    trimmed = {
+        "ok": bool(payload.get("ok", True)),
+        "connected": bool(payload.get("connected", False)),
+        "herdr_sessions": [],
+        "orca_connected": bool(payload.get("orca_connected", False)),
+        "summary": counts,
+        "agents": [],
+        "workspaces": [],
+        "truncated": True,
+    }
+    text = _dumps(trimmed)
+    if not text or len(text) > STATUS_MAX_BYTES:
+        text = _dumps({
+            "ok": True,
+            "connected": False,
+            "summary": {"total": _bounded_number(counts.get("total") or 0)},
+            "agents": [],
+            "workspaces": [],
+            "truncated": True,
+        })
+    return text
+
+
 def main() -> None:
     if len(sys.argv) < 2 or sys.argv[1] in ("fetch", "status", "--json", "-j"):
         data = fetch_all_agents()
-        print(json.dumps(data, indent=2))
+        print(dump_status_json(data))
         return
 
     cmd = sys.argv[1]

--- a/assets/icons/grok.svg
+++ b/assets/icons/grok.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <rect width="24" height="24" rx="5" fill="#9CA3AF" fill-opacity="0.15"/>
+  <!-- Original four-point spark; not the xAI wordmark -->
+  <path d="M12 3.5L13.4 10.6L20.5 12L13.4 13.4L12 20.5L10.6 13.4L3.5 12L10.6 10.6Z" fill="#D1D5DB"/>
+  <circle cx="12" cy="12" r="1.6" fill="#111827"/>
+</svg>

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "version": "1.0.0",
   "author": "meviusisback",
   "license": "MIT",
-  "description": "Live monitor and workspace orchestrator for AI coding agents (Herdr, OMP, Hermes, Claude, Codex) in the Omarchy bar.",
+  "description": "Live monitor and workspace orchestrator for AI coding agents (Herdr, OMP, Hermes, Claude, Codex, Grok) in the Omarchy bar.",
   "kinds": [
     "bar-widget"
   ],
@@ -26,7 +26,8 @@
       "refreshIntervalSec": 3,
       "barDisplay": "Icon",
       "showIdleInBar": false,
-      "maxTaskLength": 45
+      "maxTaskLength": 45,
+      "privacyHidePrompts": false
     },
     "schema": [
       {
@@ -49,7 +50,7 @@
           "Compact"
         ],
         "defaultValue": "Icon",
-        "description": "Icon shows the orchestrator glyph + badge; Status shows the top active task; Compact shows total and busy count."
+        "description": "Icon shows the orchestrator glyph + badge; Status shows the top active task; Compact shows total and busy count. With privacyHidePrompts enabled, Status falls back to the counts form so no task text is shown."
       },
       {
         "key": "showIdleInBar",
@@ -67,6 +68,13 @@
         "step": 5,
         "defaultValue": 45,
         "description": "Maximum characters shown in the bar ticker for active tasks."
+      },
+      {
+        "key": "privacyHidePrompts",
+        "type": "boolean",
+        "label": "Hide prompt text (screen sharing)",
+        "defaultValue": false,
+        "description": "Hide agent-supplied task and prompt text in the bar and cards, showing counts, status, repo and workspace only — useful when recording or sharing your screen."
       }
     ]
   }

--- a/tests/test_grok_sessions.py
+++ b/tests/test_grok_sessions.py
@@ -1,0 +1,800 @@
+#!/usr/bin/env python3
+"""Fixture tests for Grok Build session discovery in agent_ctl.py.
+
+Hermetic by construction: every case points GROK_HOME at a fresh temporary
+directory, so the suite never reads the real ~/.grok, never touches the network,
+hyprctl, Orca or Herdr, and never calls fetch_all_agents(). Only the pure Grok
+helpers run here, which keeps this safe to execute on a live desktop.
+
+Run:  python3 tests/test_grok_sessions.py
+"""
+
+import importlib.util
+import json
+import os
+import shutil
+import signal
+import sys
+import tempfile
+import unittest
+import uuid
+from unittest import mock
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _load_agent_ctl():
+    """Import agent_ctl.py from the repo without installing it as a package."""
+    spec = importlib.util.spec_from_file_location("agent_ctl_under_test", os.path.join(REPO_ROOT, "agent_ctl.py"))
+    assert spec is not None and spec.loader is not None, "cannot load agent_ctl.py"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+ac = _load_agent_ctl()
+
+# Long path whose URL-encoded form far exceeds the 255-byte group-name limit,
+# i.e. the case Grok stores as a slug+hash group with a `.cwd` marker file.
+LONG_CWD = "/home/agent/very/deep/" + "/".join("segment-%02d-abcdefghijklmnopqrstuvwxyz" % i for i in range(12))
+
+
+class GrokFixtureCase(unittest.TestCase):
+    """Common fixture helpers: temp GROK_HOME, session/event writers."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix="grok-test-")
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        patcher = mock.patch.dict(os.environ, {"GROK_HOME": self.tmp})
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        ac._GROK_BUDGET.reset()
+
+    # -- writers -----------------------------------------------------------
+    def make_session(self, group, session_id, summary=None, events=None, history=None, cwd_marker=None):
+        group_dir = os.path.join(self.tmp, "sessions", group)
+        session_dir = os.path.join(group_dir, session_id)
+        os.makedirs(session_dir, exist_ok=True)
+        with open(os.path.join(session_dir, "summary.json"), "w", encoding="utf-8") as f:
+            json.dump(summary if summary is not None else {"current_model_id": "grok-4.6", "generated_title": "Fix the build"}, f)
+        if events is not None:
+            with open(os.path.join(session_dir, "events.jsonl"), "w", encoding="utf-8") as f:
+                for entry in events:
+                    f.write(json.dumps(entry) + "\n")
+        if history is not None:
+            with open(os.path.join(session_dir, "chat_history.jsonl"), "w", encoding="utf-8") as f:
+                for entry in history:
+                    f.write(json.dumps(entry) + "\n")
+        if cwd_marker is not None:
+            with open(os.path.join(group_dir, ".cwd"), "w", encoding="utf-8") as f:
+                f.write(cwd_marker)
+        return session_dir
+
+    def write_roster(self, rows):
+        with open(os.path.join(self.tmp, "active_sessions.json"), "w", encoding="utf-8") as f:
+            json.dump(rows, f)
+
+
+class TestInvocationClassification(GrokFixtureCase):
+    def test_cli_verbs_are_not_sessions(self):
+        for verb in ac.GROK_HELPER_SUBCOMMANDS:
+            self.assertTrue(ac.is_grok_helper_process("grok %s" % verb, ["grok", verb]), verb)
+
+    def test_interactive_forms_are_sessions(self):
+        cases = [
+            ["grok"],
+            ["grok", "--resume"],
+            ["grok", "--resume", "some-title"],
+            ["grok", "--session-id", str(uuid.uuid4())],
+            ["grok", "fix the failing test"],
+            ["grok", "agent loop rewrite"],  # prompt text, not the `agent` verb
+        ]
+        for argv in cases:
+            self.assertFalse(ac.is_grok_helper_process(" ".join(argv), argv), argv)
+
+    def test_headless_and_info_invocations_are_not_sessions(self):
+        cases = [
+            ["grok", "-p", "hi"],
+            ["grok", "--single", "hi"],
+            ["grok", "--prompt-file", "/tmp/p.txt"],
+            ["grok", "--prompt-json", "[]"],
+            ["grok", "--output-format", "json", "hi"],
+            ["grok", "--json-schema", "{}"],
+            ["grok", "-v"],
+            ["grok", "--version"],
+            ["grok", "-h"],
+            ["grok", "--help"],
+            ["grok", "--show-current"],
+        ]
+        for argv in cases:
+            self.assertTrue(ac.is_grok_helper_process(" ".join(argv), argv), argv)
+
+    def test_headless_flag_late_in_argv_is_still_detected(self):
+        argv = ["grok", "--model", "grok-4.6", "--cwd", "/tmp", "-p", "hi"]
+        self.assertTrue(ac.is_grok_helper_process(" ".join(argv), argv))
+
+    def test_other_binaries_are_ignored(self):
+        self.assertFalse(ac.is_grok_helper_process("claude daemon", ["claude", "daemon"]))
+        self.assertFalse(ac.is_grok_helper_process("node /usr/bin/grok", ["node", "/usr/bin/grok"]))
+
+    def test_cwd_override_detection(self):
+        self.assertTrue(ac.grok_argv_has_cwd_override(["grok", "--cwd", "/tmp"]))
+        self.assertTrue(ac.grok_argv_has_cwd_override(["grok", "--cwd=/tmp"]))
+        self.assertFalse(ac.grok_argv_has_cwd_override(["grok", "--resume"]))
+
+
+class TestSessionIdAndTraversal(GrokFixtureCase):
+    def test_validator_rejects_traversal_and_junk(self):
+        bad = ["", "..", "../..", "/etc/passwd", "abc", "%2e%2e", "..%2f..", "....", "x" * 8, "a" * 10000, "id\n"]
+        for value in bad:
+            self.assertIsNone(ac.GROK_SESSION_ID_RE.match(value), value)
+
+    def test_validator_accepts_uuid_shape(self):
+        self.assertIsNotNone(ac.GROK_SESSION_ID_RE.match(str(uuid.uuid4())))
+
+    def test_traversal_id_resolves_nothing(self):
+        outside = tempfile.mkdtemp(prefix="grok-outside-")
+        self.addCleanup(shutil.rmtree, outside, ignore_errors=True)
+        with open(os.path.join(outside, "summary.json"), "w", encoding="utf-8") as f:
+            json.dump({"generated_title": "secret"}, f)
+        os.makedirs(os.path.join(self.tmp, "sessions"), exist_ok=True)
+        self.assertIsNone(ac.grok_session_dir_for_id("/tmp", "../../" + os.path.basename(outside)))
+        self.assertIsNone(ac.grok_session_dir_for_id("/tmp", "/etc"))
+
+
+class TestRosterResolution(GrokFixtureCase):
+    def test_pid_maps_to_session_without_matching_the_group_name(self):
+        """The session id is the key, so a slug+hash group still resolves."""
+        sid = str(uuid.uuid4())
+        session_dir = self.make_session("slug-8f2a1b3c", sid, summary={"current_model_id": "grok-4.6"})
+        self.write_roster([{"session_id": sid, "pid": os.getpid(), "cwd": "/home/agent/project", "opened_at": "2026-09-11T10:00:00Z"}])
+        self.assertEqual(ac.grok_active_session_for_pid(os.getpid()), session_dir)
+
+    def test_encoded_group_fast_path(self):
+        sid = str(uuid.uuid4())
+        cwd = "/home/agent/project"
+        session_dir = self.make_session(ac.quote(cwd, safe=""), sid)
+        self.write_roster([{"session_id": sid, "pid": os.getpid(), "cwd": cwd, "opened_at": "x"}])
+        self.assertEqual(ac.grok_active_session_for_pid(os.getpid()), session_dir)
+
+    def test_other_pid_is_not_matched(self):
+        sid = str(uuid.uuid4())
+        self.make_session("group", sid)
+        self.write_roster([{"session_id": sid, "pid": 999999, "cwd": "/tmp", "opened_at": "x"}])
+        self.assertIsNone(ac.grok_active_session_for_pid(os.getpid()))
+
+    def test_malformed_roster_is_ignored(self):
+        with open(os.path.join(self.tmp, "active_sessions.json"), "w", encoding="utf-8") as f:
+            f.write('{"session_id": "truncated')
+        self.assertIsNone(ac.grok_active_session_for_pid(os.getpid()))
+
+    def test_roster_rows_with_traversal_ids_are_dropped(self):
+        self.make_session("group", str(uuid.uuid4()))
+        self.write_roster([{"session_id": "../../etc", "pid": os.getpid(), "cwd": "/tmp", "opened_at": "x"}])
+        self.assertIsNone(ac.grok_active_session_for_pid(os.getpid()))
+
+    def test_oversized_roster_is_refused(self):
+        big = [{"session_id": str(uuid.uuid4()), "pid": os.getpid(), "cwd": "/tmp", "opened_at": "x" * 4096} for _ in range(128)]
+        self.write_roster(big)
+        self.assertGreater(os.path.getsize(os.path.join(self.tmp, "active_sessions.json")), ac.GROK_ROSTER_MAX_BYTES)
+        self.assertIsNone(ac.grok_active_session_for_pid(os.getpid()))
+
+    def test_subagent_session_is_skipped(self):
+        sid = str(uuid.uuid4())
+        self.make_session("group", sid, summary={"current_model_id": "grok-4.6", "session_kind": "subagent:explorer"})
+        self.write_roster([{"session_id": sid, "pid": os.getpid(), "cwd": "/tmp", "opened_at": "x"}])
+        self.assertIsNone(ac.grok_active_session_for_pid(os.getpid()))
+
+
+class TestPathIntegrity(GrokFixtureCase):
+    def test_symlinked_session_dir_is_not_trusted(self):
+        outside = tempfile.mkdtemp(prefix="grok-outside-")
+        self.addCleanup(shutil.rmtree, outside, ignore_errors=True)
+        sid = str(uuid.uuid4())
+        with open(os.path.join(outside, "summary.json"), "w", encoding="utf-8") as f:
+            json.dump({"generated_title": "outside"}, f)
+        group = os.path.join(self.tmp, "sessions", "group")
+        os.makedirs(group, exist_ok=True)
+        os.symlink(outside, os.path.join(group, sid))
+        self.write_roster([{"session_id": sid, "pid": os.getpid(), "cwd": "/tmp", "opened_at": "x"}])
+        self.assertFalse(ac.grok_trusted_path(os.path.join(group, sid)))
+        self.assertIsNone(ac.grok_active_session_for_pid(os.getpid()))
+        self.assertEqual(ac.extract_grok_task_from_session(os.path.join(group, sid)), (None, None, None, None, False))
+
+    def test_symlinked_summary_file_is_not_read(self):
+        sid = str(uuid.uuid4())
+        session_dir = self.make_session("group", sid, summary={"generated_title": "real"})
+        outside = tempfile.mkdtemp(prefix="grok-outside-")
+        self.addCleanup(shutil.rmtree, outside, ignore_errors=True)
+        decoy = os.path.join(outside, "summary.json")
+        with open(decoy, "w", encoding="utf-8") as f:
+            json.dump({"generated_title": "decoy"}, f)
+        os.remove(os.path.join(session_dir, "summary.json"))
+        os.symlink(decoy, os.path.join(session_dir, "summary.json"))
+        self.assertIsNone(ac.grok_read_json(os.path.join(session_dir, "summary.json"), ac.GROK_SUMMARY_MAX_BYTES))
+
+    def test_path_outside_grok_home_is_not_trusted(self):
+        outside = tempfile.mkdtemp(prefix="grok-outside-")
+        self.addCleanup(shutil.rmtree, outside, ignore_errors=True)
+        self.assertFalse(ac.grok_trusted_path(outside))
+
+    def test_group_world_writable_is_not_trusted(self):
+        sid = str(uuid.uuid4())
+        group = os.path.join(self.tmp, "sessions", "group")
+        self.make_session("group", sid)
+        os.chmod(group, 0o777)
+        self.addCleanup(os.chmod, group, 0o755)
+        self.assertFalse(ac.grok_trusted_path(os.path.join(group, sid)))
+
+
+class TestCwdResolution(GrokFixtureCase):
+    def test_encoded_group_finds_session(self):
+        cwd = "/home/agent/project"
+        sid = str(uuid.uuid4())
+        session_dir = self.make_session(ac.quote(cwd, safe=""), sid)
+        self.assertEqual(ac.grok_sessions_for_cwd(cwd), [session_dir])
+
+    def test_long_cwd_group_is_found_via_cwd_marker(self):
+        sid = str(uuid.uuid4())
+        session_dir = self.make_session("slug-abc123-deadbeef", sid, cwd_marker=LONG_CWD)
+        self.assertGreater(len(ac.quote(LONG_CWD, safe="")), 255)
+        self.assertEqual(ac.grok_sessions_for_cwd(LONG_CWD), [session_dir])
+
+    def test_unrelated_group_is_not_matched(self):
+        cwd = "/home/agent/project"
+        sid = str(uuid.uuid4())
+        self.make_session("some-other-group", sid, cwd_marker="/elsewhere")
+        self.assertEqual(ac.grok_sessions_for_cwd(cwd), [])
+
+    def test_newest_session_first(self):
+        cwd = "/home/agent/project"
+        group = ac.quote(cwd, safe="")
+        older = self.make_session(group, str(uuid.uuid4()))
+        newer = self.make_session(group, str(uuid.uuid4()))
+        os.utime(os.path.join(older, "summary.json"), (1000, 1000))
+        os.utime(os.path.join(newer, "summary.json"), (2000, 2000))
+        self.assertEqual(ac.grok_sessions_for_cwd(cwd), [newer, older])
+
+    def test_subagent_session_is_not_listed(self):
+        cwd = "/home/agent/project"
+        parent = self.make_session(ac.quote(cwd, safe=""), str(uuid.uuid4()), summary={"generated_title": "parent"})
+        self.make_session(ac.quote(cwd, safe=""), str(uuid.uuid4()), summary={"session_kind": "subagent:x"})
+        self.assertEqual(ac.grok_sessions_for_cwd(cwd), [parent])
+
+    def test_group_cwd_marker_read(self):
+        sid = str(uuid.uuid4())
+        self.make_session("slug-hash", sid, cwd_marker=LONG_CWD)
+        self.assertEqual(ac.grok_group_cwd(os.path.join(self.tmp, "sessions", "slug-hash")), LONG_CWD)
+        encoded = "/home/agent/project"
+        self.make_session(ac.quote(encoded, safe=""), str(uuid.uuid4()))
+        self.assertEqual(ac.grok_group_cwd(os.path.join(self.tmp, "sessions", ac.quote(encoded, safe=""))), encoded)
+
+
+class TestStatusMapping(GrokFixtureCase):
+    def extract(self, events=None, summary=None, history=None):
+        session_dir = self.make_session("group", str(uuid.uuid4()), summary=summary, events=events, history=history)
+        return ac.extract_grok_task_from_session(session_dir)
+
+    def test_permission_prompt_is_waiting(self):
+        prompt, detail, model, status, has_q = self.extract(events=[{"type": "phase_changed", "phase": "permission_prompt"}])
+        self.assertEqual(status, "waiting")
+        self.assertTrue(has_q)
+        self.assertIn("permission", detail.lower())
+
+    def test_permission_requested_is_waiting_with_tool(self):
+        _, detail, _, status, has_q = self.extract(events=[{"type": "permission_requested", "tool_name": "bash"}])
+        self.assertEqual(status, "waiting")
+        self.assertTrue(has_q)
+        self.assertIn("bash", detail)
+
+    def test_tool_execution_is_working(self):
+        _, detail, _, status, _ = self.extract(events=[{"type": "tool_started", "tool_name": "grep"}, {"type": "tool_completed", "tool_name": "grep"}, {"type": "phase_changed", "phase": "tool_execution"}])
+        self.assertEqual(status, "working")
+
+    def test_waiting_for_model_is_working(self):
+        _, detail, _, status, _ = self.extract(events=[{"type": "turn_started"}, {"type": "phase_changed", "phase": "waiting_for_model"}])
+        self.assertEqual(status, "working")
+        self.assertEqual(detail, "Thinking…")
+
+    def test_turn_ended_is_completed_with_turn_summary(self):
+        session_dir = self.make_session(
+            "group",
+            str(uuid.uuid4()),
+            summary={"current_model_id": "grok-4.6", "generated_title": "Fix build", "last_turn_summary": "Short answer given"},
+            events=[{"type": "turn_started"}, {"type": "turn_ended", "outcome": "completed"}],
+        )
+        _, detail, _, status, _ = ac.extract_grok_task_from_session(session_dir)
+        self.assertEqual(status, "completed")
+        self.assertEqual(detail, "Short answer given")
+
+    def test_no_events_is_idle(self):
+        _, detail, _, status, _ = self.extract()
+        self.assertEqual(status, "idle")
+        self.assertEqual(detail, "Ready for prompt")
+
+    def test_latest_user_prompt_wins_over_title(self):
+        prompt, _, _, _, _ = self.extract(
+            summary={"generated_title": "auto title"},
+            history=[{"type": "user", "content": "please fix the failing test"}, {"type": "assistant", "content": "ok"}],
+        )
+        self.assertEqual(prompt, "please fix the failing test")
+
+    def test_synthetic_and_secret_bearing_entries(self):
+        prompt, _, _, _, _ = self.extract(
+            summary={"generated_title": "auto title"},
+            history=[
+                {"type": "user", "content": "leak sk-abcdefghijklmnopqrstuvwx here"},
+                {"type": "user", "content": "synthetic", "synthetic_reason": "auto_continue"},
+            ],
+        )
+        self.assertIn("REDACTED", prompt)
+        self.assertNotIn("abcdefghijklmnopqrstuvwx", prompt)
+
+    def test_model_and_title_from_summary(self):
+        prompt, _, model, _, _ = self.extract(summary={"current_model_id": "xai/grok-4.6", "generated_title": "Rename helper"})
+        self.assertEqual(model, "grok-4.6")
+        self.assertEqual(prompt, "Rename helper")
+
+    def test_oversized_summary_is_refused_but_events_still_read(self):
+        session_dir = self.make_session("group", str(uuid.uuid4()), events=[{"type": "turn_ended"}])
+        with open(os.path.join(session_dir, "summary.json"), "w", encoding="utf-8") as f:
+            f.write(json.dumps({"generated_title": "x" * (ac.GROK_SUMMARY_MAX_BYTES + 16)}))
+        _, _, model, status, _ = ac.extract_grok_task_from_session(session_dir)
+        self.assertEqual(model, "")
+        self.assertEqual(status, "completed")
+
+
+class TestBudget(GrokFixtureCase):
+    def test_budget_stops_reads_and_listings(self):
+        sid = str(uuid.uuid4())
+        session_dir = self.make_session("group", sid)
+        ac._GROK_BUDGET.spend(ac.GROK_CYCLE_MAX_BYTES + 1)
+        self.assertTrue(ac._GROK_BUDGET.exhausted())
+        self.assertIsNone(ac.grok_read_json(os.path.join(session_dir, "summary.json"), ac.GROK_SUMMARY_MAX_BYTES))
+        self.assertEqual(ac.grok_listdir(os.path.join(self.tmp, "sessions")), [])
+        self.assertFalse(ac.grok_trusted_path(session_dir))
+
+    def test_cycle_reset_restores_reads(self):
+        sid = str(uuid.uuid4())
+        session_dir = self.make_session("group", sid)
+        ac._GROK_BUDGET.spend(ac.GROK_CYCLE_MAX_BYTES + 1)
+        ac._GROK_BUDGET.reset()
+        self.assertEqual(ac.grok_read_json(os.path.join(session_dir, "summary.json"), ac.GROK_SUMMARY_MAX_BYTES)["current_model_id"], "grok-4.6")
+
+
+class TestHostileFiles(GrokFixtureCase):
+    """Files that would otherwise hang, mislead or leak must degrade safely."""
+
+    def _with_timeout(self, seconds, fn):
+        """Run fn with an alarm so a blocking regression fails instead of hanging."""
+        def _raise(signum, frame):
+            raise AssertionError("call blocked for more than %ss" % seconds)
+
+        previous = signal.signal(signal.SIGALRM, _raise)
+        signal.setitimer(signal.ITIMER_REAL, seconds)
+        try:
+            return fn()
+        finally:
+            signal.setitimer(signal.ITIMER_REAL, 0)
+            signal.signal(signal.SIGALRM, previous)
+
+    def test_fifo_instead_of_roster_does_not_block(self):
+        os.mkfifo(os.path.join(self.tmp, "active_sessions.json"))
+        self.assertIsNone(self._with_timeout(5, lambda: ac.grok_active_session_for_pid(os.getpid())))
+
+    def test_fifo_instead_of_summary_does_not_block(self):
+        sid = str(uuid.uuid4())
+        session_dir = self.make_session("group", sid)
+        os.remove(os.path.join(session_dir, "summary.json"))
+        os.mkfifo(os.path.join(session_dir, "summary.json"))
+        self.assertIsNone(self._with_timeout(5, lambda: ac.grok_read_json(os.path.join(session_dir, "summary.json"), ac.GROK_SUMMARY_MAX_BYTES)))
+        # The session degrades to a bare idle card rather than blocking or raising.
+        self.assertEqual(self._with_timeout(5, lambda: ac.extract_grok_task_from_session(session_dir)), (None, "Ready for prompt", "", "idle", False))
+
+    def test_fifo_instead_of_events_does_not_block(self):
+        sid = str(uuid.uuid4())
+        session_dir = self.make_session("group", sid)
+        os.mkfifo(os.path.join(session_dir, "events.jsonl"))
+        _, _, _, status, _ = self._with_timeout(5, lambda: ac.extract_grok_task_from_session(session_dir))
+        self.assertEqual(status, "idle")
+
+    def test_fifo_cwd_marker_does_not_block(self):
+        group = os.path.join(self.tmp, "sessions", "g")
+        os.makedirs(group, exist_ok=True)
+        os.mkfifo(os.path.join(group, ".cwd"))
+        self.assertIsNone(self._with_timeout(5, lambda: ac.grok_group_cwd_marker(group)))
+
+    def test_hardlinked_summary_is_refused(self):
+        outside = tempfile.mkdtemp(prefix="grok-outside-")
+        self.addCleanup(shutil.rmtree, outside, ignore_errors=True)
+        planted = os.path.join(outside, "secret.json")
+        with open(planted, "w", encoding="utf-8") as f:
+            json.dump({"generated_title": "HARDLINKED"}, f)
+        sid = str(uuid.uuid4())
+        session_dir = self.make_session("group", sid)
+        os.remove(os.path.join(session_dir, "summary.json"))
+        os.link(planted, os.path.join(session_dir, "summary.json"))
+        self.assertFalse(ac.grok_is_regular_file(os.path.join(session_dir, "summary.json")))
+        self.assertIsNone(ac.grok_read_json(os.path.join(session_dir, "summary.json"), ac.GROK_SUMMARY_MAX_BYTES))
+        prompt, _, _, _, _ = ac.extract_grok_task_from_session(session_dir)
+        self.assertNotEqual(prompt, "HARDLINKED")
+
+    def test_long_but_valid_event_is_not_dropped(self):
+        """The newest event decides the status, so a large one must still parse."""
+        sid = str(uuid.uuid4())
+        events = [{"type": "turn_started"}, {"type": "permission_requested", "tool_name": "bash", "payload": "y" * 20000}]
+        session_dir = self.make_session("group", sid, events=events)
+        _, detail, _, status, has_q = ac.extract_grok_task_from_session(session_dir)
+        self.assertEqual(status, "waiting")
+        self.assertTrue(has_q)
+        self.assertIn("bash", detail)
+
+    def test_secret_in_tool_name_is_redacted(self):
+        sid = str(uuid.uuid4())
+        session_dir = self.make_session("group", sid, events=[{"type": "tool_started", "tool_name": "sk-abcdefghijklmnopqrstuvwx"}])
+        _, detail, _, status, _ = ac.extract_grok_task_from_session(session_dir)
+        self.assertEqual(status, "working")
+        self.assertIn("REDACTED", detail)
+        self.assertNotIn("abcdefghijklmnopqrstuvwx", detail)
+
+    def test_secret_in_permission_tool_name_is_redacted(self):
+        sid = str(uuid.uuid4())
+        session_dir = self.make_session("group", sid, events=[{"type": "permission_requested", "tool_name": "ghp_abcdEFGHIJKLMNOPQRSTUV"}])
+        _, detail, _, status, _ = ac.extract_grok_task_from_session(session_dir)
+        self.assertEqual(status, "waiting")
+        self.assertIn("REDACTED", detail)
+
+    def test_dot_cwd_does_not_escape_into_grok_home(self):
+        """quote() leaves '.' alone, so a roster cwd of '..' must be refused."""
+        sid = str(uuid.uuid4())
+        planted = os.path.join(self.tmp, sid)
+        os.makedirs(planted, exist_ok=True)
+        with open(os.path.join(planted, "summary.json"), "w", encoding="utf-8") as f:
+            json.dump({"generated_title": "ABOVE SESSIONS"}, f)
+        self.assertIsNone(ac.grok_session_dir_for_id("..", sid))
+        self.assertIsNone(ac.grok_session_dir_for_id(".", sid))
+
+    def test_trailing_newline_session_id_is_rejected(self):
+        self.assertIsNone(ac.GROK_SESSION_ID_RE.match(str(uuid.uuid4()) + "\n"))
+        self.assertIsNotNone(ac.GROK_SESSION_ID_RE.match(str(uuid.uuid4())))
+
+
+class TestEventOrdering(GrokFixtureCase):
+    """Event order decides the status: the newest event must win."""
+
+    def state(self, events):
+        session_dir = self.make_session("group", str(uuid.uuid4()), events=events)
+        _, detail, _, status, has_q = ac.extract_grok_task_from_session(session_dir)
+        return status, detail, has_q
+
+    def test_tool_started_after_permission_prompt_is_working(self):
+        status, detail, _ = self.state([{"type": "phase_changed", "phase": "permission_prompt"}, {"type": "tool_started", "tool_name": "bash"}])
+        self.assertEqual(status, "working")
+        self.assertIn("bash", detail)
+
+    def test_permission_resolved_clears_the_stale_phase(self):
+        status, _, _ = self.state([
+            {"type": "turn_started"},
+            {"type": "phase_changed", "phase": "permission_prompt"},
+            {"type": "permission_requested", "tool_name": "bash"},
+            {"type": "permission_resolved", "tool_name": "bash"},
+        ])
+        self.assertEqual(status, "working")
+
+    def test_permission_prompt_after_resolve_still_waits(self):
+        status, _, has_q = self.state([
+            {"type": "permission_requested", "tool_name": "bash"},
+            {"type": "permission_resolved", "tool_name": "bash"},
+            {"type": "phase_changed", "phase": "permission_prompt"},
+        ])
+        self.assertEqual(status, "waiting")
+        self.assertTrue(has_q)
+
+    def test_turn_completed_after_tools_is_completed(self):
+        status, detail, _ = self.state([
+            {"type": "turn_started"},
+            {"type": "tool_started", "tool_name": "grep"},
+            {"type": "tool_completed", "tool_name": "grep"},
+            {"type": "phase_changed", "phase": "streaming_text"},
+            {"type": "turn_ended", "outcome": "completed"},
+        ])
+        self.assertEqual(status, "completed")
+
+    def test_partial_tail_starting_mid_line_still_parses(self):
+        """A tail that starts inside a line must drop only that partial line."""
+        sid = str(uuid.uuid4())
+        session_dir = self.make_session("group", sid)
+        filler = json.dumps({"type": "phase_changed", "phase": "streaming_text", "pad": "x" * 200}) + "\n"
+        with open(os.path.join(session_dir, "events.jsonl"), "w", encoding="utf-8") as f:
+            f.write(filler * 400)
+            f.write(json.dumps({"type": "turn_ended"}) + "\n")
+        _, _, _, status, _ = ac.extract_grok_task_from_session(session_dir)
+        self.assertEqual(status, "completed")
+
+
+class TestGroupCwdMarker(GrokFixtureCase):
+    def test_marker_is_optional(self):
+        sid = str(uuid.uuid4())
+        self.make_session("plain-group", sid)
+        group = os.path.join(self.tmp, "sessions", "plain-group")
+        self.assertIsNone(ac.grok_group_cwd_marker(group))
+        self.assertEqual(ac.grok_group_cwd(group), "plain-group")
+
+    def test_marker_wins_over_group_name(self):
+        sid = str(uuid.uuid4())
+        self.make_session("slug-hash", sid, cwd_marker=LONG_CWD)
+        group = os.path.join(self.tmp, "sessions", "slug-hash")
+        self.assertEqual(ac.grok_group_cwd_marker(group), LONG_CWD)
+        self.assertEqual(ac.grok_group_cwd(group), LONG_CWD)
+
+
+class TestMarkerAndBudget(GrokFixtureCase):
+    """The `.cwd` marker is untrusted text and must not become UI text or cost."""
+
+    def test_relative_marker_text_is_rejected(self):
+        self.make_session("slug", str(uuid.uuid4()), cwd_marker="not/a/path\nINJECT")
+        group = os.path.join(self.tmp, "sessions", "slug")
+        self.assertIsNone(ac.grok_group_cwd_marker(group))
+
+    def test_marker_with_ansi_and_secret_is_cleaned(self):
+        self.make_session("slug", str(uuid.uuid4()), cwd_marker="/tmp/proj-sk-abcdefghijklmnopqrstuvwx\x1b[31m\x1b[0m")
+        group = os.path.join(self.tmp, "sessions", "slug")
+        marker = ac.grok_group_cwd_marker(group)
+        self.assertIsNotNone(marker)
+        self.assertNotIn("\x1b", marker)
+        self.assertIn("REDACTED", marker)
+        self.assertNotIn("abcdefghijklmnopqrstuvwx", marker)
+
+    def test_marker_read_is_memoized_per_cycle(self):
+        self.make_session("slug", str(uuid.uuid4()), cwd_marker="/tmp/proj")
+        group = os.path.join(self.tmp, "sessions", "slug")
+        ac._GROK_BUDGET.reset()
+        first = ac.grok_group_cwd_marker(group)
+        ops_after_first = ac._GROK_BUDGET.ops
+        second = ac.grok_group_cwd_marker(group)
+        self.assertEqual(first, second)
+        self.assertEqual(ac._GROK_BUDGET.ops, ops_after_first)
+
+    def test_many_marker_groups_still_resolve_within_budget(self):
+        """A 200-group marker-bearing tree must not exhaust the op budget."""
+        target_cwd = "/home/agent/target-project"
+        dirs = {}
+        for i in range(200):
+            cwd = "/home/agent/other-%03d" % i
+            dirs[cwd] = self.make_session("slug-%03d" % i, str(uuid.uuid4()), cwd_marker=cwd)
+        session_dir = self.make_session("slug-target", str(uuid.uuid4()), cwd_marker=target_cwd)
+        ac._GROK_BUDGET.reset()
+        found = ac.grok_sessions_for_cwd(target_cwd)
+        self.assertIn(session_dir, found)
+        self.assertFalse(ac._GROK_BUDGET.exhausted(), "op budget exhausted at %d ops" % ac._GROK_BUDGET.ops)
+        # A second card in the same tick must still resolve.
+        self.assertEqual(ac.grok_sessions_for_cwd("/home/agent/other-199"), [dirs["/home/agent/other-199"]])
+
+    def test_roster_is_read_once_per_cycle(self):
+        sid = str(uuid.uuid4())
+        self.make_session("group", sid)
+        self.write_roster([{"session_id": sid, "pid": os.getpid(), "cwd": "/tmp", "opened_at": "x"}])
+        ac._GROK_BUDGET.reset()
+        self.assertIsNotNone(ac.grok_active_session_for_pid(os.getpid()))
+        bytes_after_first = ac._GROK_BUDGET.bytes_read
+        self.assertIsNotNone(ac.grok_active_session_for_pid(os.getpid()))
+        self.assertEqual(ac._GROK_BUDGET.bytes_read, bytes_after_first)
+
+    def test_whole_file_read_refused_when_allowance_is_smaller(self):
+        """A read that the remaining allowance would truncate is refused outright.
+
+        Accepting the prefix would mean parsing half a JSON document (or, for a
+        marker, a wrong path), so the reader fails closed instead of guessing.
+        """
+        sid = str(uuid.uuid4())
+        session_dir = self.make_session("group", sid)
+        path = os.path.join(session_dir, "summary.json")
+        size = os.path.getsize(path)
+        self.assertGreater(size, 10)
+        ac._GROK_BUDGET.reset()
+        ac._GROK_BUDGET.bytes_read = ac.GROK_CYCLE_MAX_BYTES - (size - 1)
+        self.assertIsNone(ac.grok_read_bytes(path, ac.GROK_SUMMARY_MAX_BYTES))
+        ac._GROK_BUDGET.reset()
+        ac._GROK_BUDGET.bytes_read = ac.GROK_CYCLE_MAX_BYTES - size
+        data = ac.grok_read_bytes(path, ac.GROK_SUMMARY_MAX_BYTES)
+        self.assertEqual(len(data), size)
+        self.assertLessEqual(ac._GROK_BUDGET.bytes_read, ac.GROK_CYCLE_MAX_BYTES)
+
+
+class TestLargeEventsAndStatusPayload(GrokFixtureCase):
+    def test_single_huge_event_line_still_sets_status(self):
+        """A decisive event larger than the 64 KiB window must not be lost."""
+        sid = str(uuid.uuid4())
+        session_dir = self.make_session("group", sid)
+        with open(os.path.join(session_dir, "events.jsonl"), "w", encoding="utf-8") as f:
+            f.write(json.dumps({"type": "taskId", "pad": "z" * 100000}) + "\n")
+            f.write(json.dumps({"type": "permission_requested", "tool_name": "bash", "payload": "z" * 100000}) + "\n")
+        _, detail, _, status, _ = ac.extract_grok_task_from_session(session_dir)
+        self.assertEqual(status, "waiting")
+        self.assertIn("bash", detail)
+
+    def test_model_id_is_redacted(self):
+        sid = str(uuid.uuid4())
+        session_dir = self.make_session("group", sid, summary={"current_model_id": "xai/sk-abcdefghijklmnopqrstuvwx", "generated_title": "x"})
+        _, _, model, _, _ = ac.extract_grok_task_from_session(session_dir)
+        self.assertNotIn("abcdefghijklmnopqrstuvwx", model)
+        self.assertIn("REDACTED", model)
+
+    def test_status_payload_caps_agents(self):
+        payload = {"ok": True, "connected": False, "summary": {"total": 300}, "agents": [{"pane_id": "x%d" % i, "title": "t"} for i in range(300)], "workspaces": []}
+        text = ac.dump_status_json(payload)
+        parsed = json.loads(text)
+        self.assertEqual(len(parsed["agents"]), ac.STATUS_MAX_AGENTS)
+
+    def test_status_payload_overflow_in_summary_only(self):
+        """An oversized headline (not agents) must still respect the ceiling."""
+        payload = {
+            "ok": True,
+            "connected": False,
+            "summary": {"total": 1, "working": 1, "headline": "Grok: " + "y" * 900000},
+            "agents": [{"pane_id": "p", "title": "t", "detail": "d"}],
+            "workspaces": ["w"],
+        }
+        text = ac.dump_status_json(payload)
+        self.assertLessEqual(len(text), ac.STATUS_MAX_BYTES)
+        # What the panel actually does: slice, then parse — the headline is clipped
+        # rather than allowed to blow the reply past the panel's own truncation.
+        parsed = json.loads(text[:ac.STATUS_MAX_BYTES])
+        self.assertLessEqual(len(parsed["summary"]["headline"]), 300)
+
+    def test_hostile_large_markers_do_not_starve_real_reads(self):
+        """A tree of maximum-size markers must not hide a real long-path card."""
+        target_cwd = "/home/agent/wanted"
+        for i in range(200):
+            self.make_session("hostile-%03d" % i, str(uuid.uuid4()), cwd_marker="x" * ac.GROK_CWD_MARKER_MAX_BYTES)
+        session_dir = self.make_session("hostile-target", str(uuid.uuid4()), cwd_marker=target_cwd, summary={"generated_title": "real work"})
+        ac._GROK_BUDGET.reset()
+        found = ac.grok_sessions_for_cwd(target_cwd)
+        # The marker allowance is sized for the whole group scan, so the real
+        # session is still discovered after a flood of maximum-size markers.
+        self.assertIn(session_dir, found)
+        self.assertFalse(ac._GROK_BUDGET.exhausted(), "budget exhausted by markers at %d bytes" % ac._GROK_BUDGET.bytes_read)
+        self.assertLessEqual(ac._GROK_BUDGET.marker_bytes, ac.GROK_MARKER_MAX_TOTAL_BYTES)
+        prompt, _, _, _, _ = ac.extract_grok_task_from_session(session_dir)
+        self.assertEqual(prompt, "real work")
+
+    def test_marker_groups_cannot_hijack_the_encoded_group(self):
+        """A marker merely claiming the cwd must not outrank the encoded group."""
+        cwd = "/home/agent/shared"
+        legit = self.make_session(ac.quote(cwd, safe=""), str(uuid.uuid4()), summary={"generated_title": "legit"}, events=[{"type": "permission_requested", "tool_name": "bash"}])
+        for i in range(4):
+            plant = self.make_session("plant-%d" % i, str(uuid.uuid4()), cwd_marker=cwd, summary={"generated_title": "HIJACK"})
+            os.utime(os.path.join(plant, "summary.json"), (10 ** 6, 10 ** 6))  # far newer
+        ac._GROK_BUDGET.reset()
+        found = ac.grok_sessions_for_cwd(cwd)
+        self.assertEqual(found[0], legit)
+        _, _, _, status, _ = ac.extract_grok_task_from_session(found[0])
+        self.assertEqual(status, "waiting")
+
+    def test_marker_matches_rank_by_recency(self):
+        """A name-sorting decoy must not outrank a newer real session."""
+        cwd = "/home/agent/long-path-project"
+        decoy = self.make_session("aaa-decoy", str(uuid.uuid4()), cwd_marker=cwd, summary={"generated_title": "HIJACK"})
+        legit = self.make_session("zzz-legit", str(uuid.uuid4()), cwd_marker=cwd, summary={"generated_title": "real work"})
+        os.utime(os.path.join(decoy, "summary.json"), (1000, 1000))
+        os.utime(os.path.join(legit, "summary.json"), (2 * 10 ** 6, 2 * 10 ** 6))
+        ac._GROK_BUDGET.reset()
+        found = ac.grok_sessions_for_cwd(cwd)
+        self.assertEqual(found[0], legit)
+
+    def test_many_claiming_groups_do_not_hide_the_newest_real_session(self):
+        """Groups are ranked by recency before the cap, so the real newest wins."""
+        cwd = "/home/agent/contested"
+        for i in range(70):
+            plant = self.make_session("claim-%03d" % i, str(uuid.uuid4()), cwd_marker=cwd, summary={"generated_title": "plant"})
+            os.utime(os.path.join(plant, "summary.json"), (1000, 1000))
+        legit = self.make_session("zzz-legit", str(uuid.uuid4()), cwd_marker=cwd, summary={"generated_title": "real work"})
+        os.utime(os.path.join(legit, "summary.json"), (2 * 10 ** 6, 2 * 10 ** 6))
+        ac._GROK_BUDGET.reset()
+        found = ac.grok_sessions_for_cwd(cwd)
+        self.assertEqual(found[0], legit)
+        self.assertLessEqual(len(found), ac.GROK_MAX_CWD_SESSIONS)
+
+    def test_per_group_session_cap_selects_newest_not_alphabetical(self):
+        """The per-group cap picks the newest sessions, not the alphabetically first."""
+        cwd = "/home/agent/big-group"
+        group = ac.grok_group_dir_for_name(ac.quote(cwd, safe=""))
+        self.assertIsNotNone(group)
+        for i in range(40):
+            name = "s-%02d" % i
+            d = os.path.join(group, name)
+            os.makedirs(d, exist_ok=True)
+            with open(os.path.join(d, "summary.json"), "w") as f:
+                json.dump({"generated_title": "t%d" % i}, f)
+            os.utime(os.path.join(d, "summary.json"), (1000 + i, 1000 + i))
+        newest = os.path.join(group, "z-newest")
+        os.makedirs(newest, exist_ok=True)
+        with open(os.path.join(newest, "summary.json"), "w") as f:
+            json.dump({"generated_title": "newest"}, f)
+        os.utime(os.path.join(newest, "summary.json"), (9 * 10 ** 6, 9 * 10 ** 6))
+        ac._GROK_BUDGET.reset()
+        found = ac.grok_sessions_for_cwd(cwd)
+        self.assertEqual(found[0], newest)
+        self.assertIn(newest, found)
+
+    def test_subagent_only_groups_do_not_hide_real_session(self):
+        """Claiming groups that yield only subagent sessions are skipped."""
+        cwd = "/home/agent/subagent-trap"
+        for i in range(ac.GROK_MAX_MATCHED_GROUPS + 5):
+            d = self.make_session("sub-%03d" % i, str(uuid.uuid4()), cwd_marker=cwd,
+                                  summary={"session_kind": "subagent:x", "generated_title": "sub"})
+            os.utime(os.path.join(d, "summary.json"), (8 * 10 ** 6, 8 * 10 ** 6))
+        real = self.make_session("aaa-real", str(uuid.uuid4()), cwd_marker=cwd,
+                                 summary={"generated_title": "real work"})
+        os.utime(os.path.join(real, "summary.json"), (10 ** 6, 10 ** 6))
+        ac._GROK_BUDGET.reset()
+        found = ac.grok_sessions_for_cwd(cwd)
+        self.assertEqual(found, [real])
+
+    def test_truncated_marker_is_never_accepted(self):
+        self.make_session("slug", str(uuid.uuid4()), cwd_marker="/home/agent/project-with-a-long-name")
+        group = os.path.join(self.tmp, "sessions", "slug")
+        ac._GROK_BUDGET.reset()
+        ac._GROK_BUDGET.marker_bytes = ac.GROK_MARKER_MAX_TOTAL_BYTES - 10
+        self.assertIsNone(ac.grok_read_marker_bytes(os.path.join(group, ".cwd")))
+        self.assertIsNone(ac.grok_group_cwd_marker(group))
+
+    def test_partial_budget_still_reads_the_newest_event(self):
+        """A clamped tail read must return the NEWEST bytes, not the oldest."""
+        sid = str(uuid.uuid4())
+        session_dir = self.make_session("group", sid, events=[{"type": "turn_started"}, {"type": "turn_ended", "outcome": "completed"}])
+        ac._GROK_BUDGET.reset()
+        ac._GROK_BUDGET.bytes_read = ac.GROK_CYCLE_MAX_BYTES - 5000
+        _, _, _, status, _ = ac.extract_grok_task_from_session(session_dir)
+        self.assertEqual(status, "completed")
+
+    def test_control_bytes_are_stripped_from_prompt_and_turn_summary(self):
+        sid = str(uuid.uuid4())
+        session_dir = self.make_session(
+            "group",
+            sid,
+            summary={"generated_title": "t", "last_turn_summary": "\x1b[31mRED\x07\x00DONE"},
+            events=[{"type": "turn_started"}, {"type": "turn_ended"}],
+            history=[{"type": "user", "content": "\x1b]8;;http://evil.example/x\x07CLICK\x1b]8;;\x07 \x00prompt"}],
+        )
+        prompt, detail, _, status, _ = ac.extract_grok_task_from_session(session_dir)
+        for value in (prompt, detail):
+            self.assertFalse(any(ch in value for ch in ("\x1b", "\x07", "\x00")), repr(value))
+        self.assertIn("CLICK", prompt)
+        self.assertIn("DONE", detail)
+
+    def test_status_payload_survives_pathological_numbers(self):
+        text = ac.dump_status_json({"ok": True, "summary": {"total": 10 ** 6000, "headline": "h"}, "agents": [], "workspaces": []})
+        self.assertLessEqual(len(text), ac.STATUS_MAX_BYTES)
+        json.loads(text)
+        text = ac.dump_status_json({"ok": True, "summary": {"total": {1, 2}}, "agents": [], "workspaces": []})
+        json.loads(text)
+
+    def test_marker_with_nul_or_space_is_rejected(self):
+        for marker in ["/tmp/a\x00b", "/tmp/a b", "/tmp/a\nb"]:
+            self.make_session("slug-nul", str(uuid.uuid4()), cwd_marker=marker)
+            group = os.path.join(self.tmp, "sessions", "slug-nul")
+            ac._GROK_BUDGET.reset()
+            self.assertIsNone(ac.grok_group_cwd_marker(group), repr(marker))
+
+    def test_status_payload_falls_back_to_valid_json(self):
+        """When clipping still cannot fit, the reply degrades to counts only."""
+        bulky = {("field%02d" % n): "y" * 400 for n in range(40)}
+        payload = {
+            "ok": True,
+            "connected": True,
+            "summary": {"total": 1, "headline": "z" * 400},
+            "agents": [dict(bulky, pane_id="p%d" % i) for i in range(256)],
+            "workspaces": [],
+        }
+        text = ac.dump_status_json(payload)
+        self.assertLessEqual(len(text), ac.STATUS_MAX_BYTES)
+        parsed = json.loads(text)
+        self.assertTrue(parsed.get("truncated"))
+        self.assertEqual(parsed["agents"], [])
+        # The panel's own slice-then-parse stays valid too.
+        json.loads(text[:ac.STATUS_MAX_BYTES])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Stacked on [@ltlgrnaiml](https://github.com/ltlgrnaiml)'s [#14](https://github.com/meviusisback/agent-orchestr/pull/14) (cherry-picked with `-x`, authorship preserved). This PR adds security hardening, a hermetic test suite, a privacy toggle, and honest documentation on top of the original Grok session discovery.

## What this adds to #14

### Session resolution (agent_ctl.py)
- Resolve a live session from its **uuid via a bounded group scan**, so the slug+hash group Grok uses for long paths (>255 bytes encoded) is found without guessing its name; the encoded-cwd fast path is tried first and short-circuits the scan.
- Validate `session_id` against `\A[0-9a-fA-F-]{8,64}\Z` before it becomes a path component; reject dot components and paths outside `$GROK_HOME/sessions/`.
- `--cwd` distrust: when the invocation passes `--cwd`, the process working directory is ignored and the session's own cwd (roster or `.cwd` marker) is shown.
- Ordered status machine: events fold in log order, so a `tool_started` after a `permission_prompt` correctly reports "working"; stale permission phases are cleared on `permission_resolved`.

### Guarded reads (agent_ctl.py)
- One guarded reader owns every file input: `O_NOFOLLOW | O_NONBLOCK` open, then fd-level verification (regular file, uid, single link, size cap, containment in `$GROK_HOME` via `/proc/self/fd` realpath).
- Per-file caps plus a per-cycle byte budget (2 MiB) and a marker sub-budget (2 MiB). Whole-file reads refuse a file the remaining allowance cannot cover.
- Backward chunk JSONL tail reader: newest events decide status; widens in chunks up to 512 KiB without re-charging.
- LRU memo (128 entries, keyed on inode+mtime+ctime+size+cap) plus memoized trust/group/marker verdicts.

### Redaction and payload bounding (agent_ctl.py)
- Every agent-supplied string passes through `grok_clean_detail` (redact_secrets + clean_ansi + C0/C1 strip + flatten + cap) or `clean_user_prompt`/`extract_first_line` which now include the same control-byte stripping.
- `dump_status_json` bounds the payload: 256-agent cap, string clips, numeric bounds, counts-only fallback. Collector exec'd directly (no `sh | head` pipeline) so the stall timer can reap it.

### `privacyHidePrompts` setting (Panel.qml, Model.js, manifest.json)
- Bar ticker, card title, card detail, tab/pane labels, and bar headline hidden; counts, status, repo breadcrumb and workspace name remain.

### Tests (tests/test_grok_sessions.py — 77 cases, all hermetic)
Covers: FIFO non-blocking, symlink/hardlink refusal, long-line JSONL parsing, ordered status table, 200-group budget headroom, marker recency ordering, subagent-only group bypass, read clamping, redaction on every field, payload overflow, truncated marker refusal, and the stall timer.

### Known limits (documented in README, honest not aspirational)
- Session resolution uses the documented URL-encoding plus `.cwd` markers; three schema assumptions called out in the README.
- Cwd-only fallback considers up to 64 `.cwd`-claiming groups ranked by recency; a locally planted newer session there can win that card. PID-resolved cards never consult markers.
- Event line > 512 KiB dropped. Path guard reads POSIX mode bits (ACLs undetected). Descriptor containment needs `/proc` (Linux-only). Ancestor-path TOCTOU not fully closed without `openat` chain.

## Verification
- `py_compile`, `manifest.json`, `omarchy plugin validate .`, `grok.svg` all clean.
- 77 tests pass. Five review rounds (20 reviewer-subagents) with verified PoCs and regression tests.

## Still needed
- End-to-end VM test (guest SSH setup incomplete). Infographic (needs Grok card screenshot).

## Credits
- [@ltlgrnaiml](https://github.com/ltlgrnaiml) — original Grok session discovery (PR #14, cherry-picked in `9f52b52`).
